### PR TITLE
refactor: inject logger service

### DIFF
--- a/src/services/chat/ChatMemory.ts
+++ b/src/services/chat/ChatMemory.ts
@@ -1,7 +1,11 @@
 import { inject, injectable } from 'inversify';
 
 import { ChatMessage } from '../ai/AIService.interface';
-import { createPinoLogger } from '../logging/logger';
+import type Logger from '../logging/Logger.interface';
+import {
+  LOGGER_SERVICE_ID,
+  type LoggerService,
+} from '../logging/LoggerService';
 import {
   INTEREST_MESSAGE_STORE_ID,
   type InterestMessageStore,
@@ -23,30 +27,35 @@ import { HISTORY_SUMMARIZER_ID, HistorySummarizer } from './HistorySummarizer';
 
 @injectable()
 export class ChatMemory {
-  private readonly logger = createPinoLogger();
+  private readonly logger: Logger;
 
   constructor(
     private messages: MessageService,
     private summarizer: HistorySummarizer,
     private localStore: InterestMessageStore,
     private chatId: number,
-    private limit: number
-  ) {}
+    private limit: number,
+    private loggerService: LoggerService
+  ) {
+    this.logger = this.loggerService.createLogger();
+  }
 
   public async addMessage(message: StoredMessage): Promise<void> {
-    this.logger.debug(
-      { chatId: this.chatId, role: message.role, limit: this.limit },
-      'Adding message'
-    );
+    this.logger.debug('Adding message', {
+      chatId: this.chatId,
+      role: message.role,
+      limit: this.limit,
+    });
     await this.messages.addMessage({ ...message, chatId: this.chatId });
     this.localStore.addMessage({ ...message, chatId: this.chatId });
 
     // Проверяем лимит после добавления сообщения
     const history = await this.messages.getMessages(this.chatId);
-    this.logger.debug(
-      { chatId: this.chatId, historyLength: history.length, limit: this.limit },
-      'Checking history limit after adding message'
-    );
+    this.logger.debug('Checking history limit after adding message', {
+      chatId: this.chatId,
+      historyLength: history.length,
+      limit: this.limit,
+    });
     const summarized = await this.summarizer.summarize(
       this.chatId,
       history,
@@ -64,30 +73,34 @@ export class ChatMemory {
 
 @injectable()
 export class ChatMemoryManager {
-  private readonly logger = createPinoLogger();
+  private readonly logger: Logger;
 
   constructor(
     @inject(MESSAGE_SERVICE_ID) private messages: MessageService,
     @inject(HISTORY_SUMMARIZER_ID) private summarizer: HistorySummarizer,
     @inject(CHAT_RESET_SERVICE_ID) private resetService: ChatResetService,
     @inject(INTEREST_MESSAGE_STORE_ID) private localStore: InterestMessageStore,
-    @inject(CHAT_CONFIG_SERVICE_ID) private config: ChatConfigService
-  ) {}
+    @inject(CHAT_CONFIG_SERVICE_ID) private config: ChatConfigService,
+    @inject(LOGGER_SERVICE_ID) private loggerService: LoggerService
+  ) {
+    this.logger = this.loggerService.createLogger();
+  }
 
   public async get(chatId: number): Promise<ChatMemory> {
-    this.logger.debug({ chatId }, 'Creating chat memory');
+    this.logger.debug('Creating chat memory', { chatId });
     const { historyLimit } = await this.config.getConfig(chatId);
     return new ChatMemory(
       this.messages,
       this.summarizer,
       this.localStore,
       chatId,
-      historyLimit
+      historyLimit,
+      this.loggerService
     );
   }
 
   public async reset(chatId: number): Promise<void> {
-    this.logger.debug({ chatId }, 'Resetting chat memory');
+    this.logger.debug('Resetting chat memory', { chatId });
     await this.resetService.reset(chatId);
     this.localStore.clearMessages(chatId);
   }

--- a/src/services/chat/DefaultChatResetService.ts
+++ b/src/services/chat/DefaultChatResetService.ts
@@ -1,6 +1,10 @@
 import { inject, injectable } from 'inversify';
 
-import { createPinoLogger } from '../logging/logger';
+import type Logger from '../logging/Logger.interface';
+import {
+  LOGGER_SERVICE_ID,
+  type LoggerService,
+} from '../logging/LoggerService';
 import {
   MESSAGE_SERVICE_ID,
   type MessageService,
@@ -13,14 +17,17 @@ import { ChatResetService } from './ChatResetService.interface';
 
 @injectable()
 export class DefaultChatResetService implements ChatResetService {
-  private readonly logger = createPinoLogger();
+  private readonly logger: Logger;
   constructor(
     @inject(MESSAGE_SERVICE_ID) private messages: MessageService,
-    @inject(SUMMARY_SERVICE_ID) private summaries: SummaryService
-  ) {}
+    @inject(SUMMARY_SERVICE_ID) private summaries: SummaryService,
+    @inject(LOGGER_SERVICE_ID) private loggerService: LoggerService
+  ) {
+    this.logger = this.loggerService.createLogger();
+  }
 
   async reset(chatId: number): Promise<void> {
-    this.logger.debug({ chatId }, 'Resetting chat data');
+    this.logger.debug('Resetting chat data', { chatId });
     await this.messages.clearMessages(chatId);
     await this.summaries.clearSummary(chatId);
   }

--- a/src/services/prompts/FilePromptService.ts
+++ b/src/services/prompts/FilePromptService.ts
@@ -3,7 +3,11 @@ import { inject, injectable } from 'inversify';
 
 import { createLazy } from '../../utils/lazy';
 import { ENV_SERVICE_ID, EnvService } from '../env/EnvService';
-import { createPinoLogger } from '../logging/logger';
+import type Logger from '../logging/Logger.interface';
+import {
+  LOGGER_SERVICE_ID,
+  type LoggerService,
+} from '../logging/LoggerService';
 import { PromptService } from './PromptService.interface';
 
 @injectable()
@@ -18,10 +22,14 @@ export class FilePromptService implements PromptService {
   private readonly assessUsersTemplate: () => Promise<string>;
   private readonly priorityRulesSystemTemplate: () => Promise<string>;
   private readonly replyTriggerTemplate: () => Promise<string>;
-  private readonly logger = createPinoLogger();
+  private readonly logger: Logger;
 
-  constructor(@inject(ENV_SERVICE_ID) envService: EnvService) {
+  constructor(
+    @inject(ENV_SERVICE_ID) envService: EnvService,
+    @inject(LOGGER_SERVICE_ID) private loggerService: LoggerService
+  ) {
     const files = envService.getPromptFiles();
+    this.logger = this.loggerService.createLogger();
     this.persona = createLazy(async () => {
       this.logger.debug('Loading persona file');
       return readFile(files.persona, 'utf-8');

--- a/src/services/summaries/RepositorySummaryService.ts
+++ b/src/services/summaries/RepositorySummaryService.ts
@@ -4,28 +4,35 @@ import {
   SUMMARY_REPOSITORY_ID,
   type SummaryRepository,
 } from '../../repositories/interfaces/SummaryRepository.interface';
-import { createPinoLogger } from '../logging/logger';
+import type Logger from '../logging/Logger.interface';
+import {
+  LOGGER_SERVICE_ID,
+  type LoggerService,
+} from '../logging/LoggerService';
 import { SummaryService } from './SummaryService.interface';
 
 @injectable()
 export class RepositorySummaryService implements SummaryService {
-  private readonly logger = createPinoLogger();
+  private readonly logger: Logger;
   constructor(
-    @inject(SUMMARY_REPOSITORY_ID) private summaryRepo: SummaryRepository
-  ) {}
+    @inject(SUMMARY_REPOSITORY_ID) private summaryRepo: SummaryRepository,
+    @inject(LOGGER_SERVICE_ID) private loggerService: LoggerService
+  ) {
+    this.logger = this.loggerService.createLogger();
+  }
 
   async getSummary(chatId: number): Promise<string> {
-    this.logger.debug({ chatId }, 'Fetching summary');
+    this.logger.debug('Fetching summary', { chatId });
     return this.summaryRepo.findById(chatId);
   }
 
   async setSummary(chatId: number, summary: string): Promise<void> {
-    this.logger.debug({ chatId }, 'Storing summary');
+    this.logger.debug('Storing summary', { chatId });
     await this.summaryRepo.upsert(chatId, summary);
   }
 
   async clearSummary(chatId: number): Promise<void> {
-    this.logger.debug({ chatId }, 'Clearing summary');
+    this.logger.debug('Clearing summary', { chatId });
     await this.summaryRepo.clearByChatId(chatId);
   }
 }

--- a/test/ChatMemory.test.ts
+++ b/test/ChatMemory.test.ts
@@ -12,6 +12,18 @@ import {
 } from '../src/services/messages/InterestMessageStore';
 import { MessageService } from '../src/services/messages/MessageService.interface';
 import { StoredMessage } from '../src/services/messages/StoredMessage.interface';
+import type { LoggerService } from '../src/services/logging/LoggerService';
+
+const createLoggerService = (): LoggerService =>
+  ({
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(),
+    }),
+  }) as unknown as LoggerService;
 
 class FakeHistorySummarizer implements HistorySummarizer {
   summarize = vi.fn(async () => false);
@@ -61,7 +73,14 @@ describe('ChatMemory', () => {
     summarizer = new FakeHistorySummarizer();
     messages = new FakeMessageService();
     localStore = new FakeInterestMessageStore();
-    memory = new ChatMemory(messages, summarizer, localStore, 1, 2);
+    memory = new ChatMemory(
+      messages,
+      summarizer,
+      localStore,
+      1,
+      2,
+      createLoggerService()
+    );
   });
 
   it('passes history to summarizer after saving message', async () => {
@@ -178,7 +197,8 @@ describe('ChatMemoryManager', () => {
       summarizer,
       new DummyResetService(),
       new DummyInterestMessageStore(),
-      config
+      config,
+      createLoggerService()
     );
     const mem = await manager.get(5);
     await mem.addMessage({ chatId: 5, role: 'user', content: 'hi' });
@@ -198,7 +218,8 @@ describe('ChatMemoryManager', () => {
       new FakeHistorySummarizer(),
       reset,
       local,
-      new DummyChatConfigService(2)
+      new DummyChatConfigService(2),
+      createLoggerService()
     );
     await manager.reset(7);
     expect(reset.reset).toHaveBeenCalledWith(7);

--- a/test/ChatResetService.test.ts
+++ b/test/ChatResetService.test.ts
@@ -2,12 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { MessageService } from '../src/services/messages/MessageService.interface';
 import type { SummaryService } from '../src/services/summaries/SummaryService.interface';
-
-const debug = vi.fn();
-vi.mock('../src/services/logging/logger', () => ({
-  createPinoLogger: () => ({ debug }),
-}));
-
+import type { LoggerService } from '../src/services/logging/LoggerService';
 import { DefaultChatResetService } from '../src/services/chat/DefaultChatResetService';
 
 describe('DefaultChatResetService', () => {
@@ -20,10 +15,20 @@ describe('DefaultChatResetService', () => {
   } as unknown as SummaryService;
 
   let service: DefaultChatResetService;
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  };
+  const loggerService: LoggerService = {
+    createLogger: () => logger,
+  } as unknown as LoggerService;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    service = new DefaultChatResetService(messages, summaries);
+    service = new DefaultChatResetService(messages, summaries, loggerService);
   });
 
   it('clears messages, summary and logs reset', async () => {
@@ -31,6 +36,8 @@ describe('DefaultChatResetService', () => {
     await service.reset(chatId);
     expect(messages.clearMessages).toHaveBeenCalledWith(chatId);
     expect(summaries.clearSummary).toHaveBeenCalledWith(chatId);
-    expect(debug).toHaveBeenCalledWith({ chatId }, 'Resetting chat data');
+    expect(logger.debug).toHaveBeenCalledWith('Resetting chat data', {
+      chatId,
+    });
   });
 });

--- a/test/DialogueManager.test.ts
+++ b/test/DialogueManager.test.ts
@@ -5,6 +5,7 @@ import {
   type DialogueManager,
 } from '../src/services/chat/DialogueManager';
 import { TestEnvService } from '../src/services/env/EnvService';
+import type { LoggerService } from '../src/services/logging/LoggerService';
 
 describe('DialogueManager', () => {
   beforeEach(() => {
@@ -14,7 +15,16 @@ describe('DialogueManager', () => {
   it('deactivates after timeout', () => {
     const env = new TestEnvService();
     vi.spyOn(env, 'getDialogueTimeoutMs').mockReturnValue(1000);
-    const dm: DialogueManager = new DefaultDialogueManager(env);
+    const loggerService: LoggerService = {
+      createLogger: () => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        child: vi.fn(),
+      }),
+    } as unknown as LoggerService;
+    const dm: DialogueManager = new DefaultDialogueManager(env, loggerService);
     dm.start(1);
     expect(dm.isActive(1)).toBe(true);
     vi.advanceTimersByTime(1000);
@@ -24,7 +34,16 @@ describe('DialogueManager', () => {
   it('extend resets timer', () => {
     const env = new TestEnvService();
     vi.spyOn(env, 'getDialogueTimeoutMs').mockReturnValue(1000);
-    const dm: DialogueManager = new DefaultDialogueManager(env);
+    const loggerService: LoggerService = {
+      createLogger: () => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        child: vi.fn(),
+      }),
+    } as unknown as LoggerService;
+    const dm: DialogueManager = new DefaultDialogueManager(env, loggerService);
     dm.start(1);
     vi.advanceTimersByTime(900);
     dm.extend(1);

--- a/test/HistorySummarizer.test.ts
+++ b/test/HistorySummarizer.test.ts
@@ -11,6 +11,7 @@ import type {
 import { DefaultHistorySummarizer } from '../src/services/chat/HistorySummarizer';
 import type { MessageService } from '../src/services/messages/MessageService.interface';
 import type { SummaryService } from '../src/services/summaries/SummaryService.interface';
+import type { LoggerService } from '../src/services/logging/LoggerService';
 
 class MockAIService implements AIService {
   summarize = vi.fn(async () => 'new summary');
@@ -86,6 +87,15 @@ describe('HistorySummarizer', () => {
   let summaries: MockSummaryService;
   let summarizer: DefaultHistorySummarizer;
   let users: MockUserRepository;
+  const loggerService: LoggerService = {
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(),
+    }),
+  } as unknown as LoggerService;
 
   beforeEach(() => {
     ai = new MockAIService();
@@ -94,7 +104,13 @@ describe('HistorySummarizer', () => {
     users = new MockUserRepository();
     users.attitudes.set(1, 'neutral');
     users.attitudes.set(2, 'hostile');
-    summarizer = new DefaultHistorySummarizer(ai, summaries, messages, users);
+    summarizer = new DefaultHistorySummarizer(
+      ai,
+      summaries,
+      messages,
+      users,
+      loggerService
+    );
   });
 
   it('does not summarize when history is within limit', async () => {

--- a/test/PromptService.test.ts
+++ b/test/PromptService.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { TestEnvService } from '../src/services/env/EnvService';
 import type { FilePromptService } from '../src/services/prompts/FilePromptService';
+import type { LoggerService } from '../src/services/logging/LoggerService';
 
 class TempEnvService extends TestEnvService {
   constructor(private dir: string) {
@@ -89,7 +90,16 @@ describe('FilePromptService', () => {
       '../src/services/prompts/FilePromptService'
     );
     const env = new TempEnvService(dir);
-    service = new FilePromptService(env);
+    const loggerService: LoggerService = {
+      createLogger: () => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        child: vi.fn(),
+      }),
+    } as unknown as LoggerService;
+    service = new FilePromptService(env, loggerService);
   });
 
   afterEach(() => {

--- a/test/RepositoryMessageService.test.ts
+++ b/test/RepositoryMessageService.test.ts
@@ -6,6 +6,7 @@ import { type MessageRepository } from '../src/repositories/interfaces/MessageRe
 import { type UserRepository } from '../src/repositories/interfaces/UserRepository.interface';
 import { RepositoryMessageService } from '../src/services/messages/RepositoryMessageService';
 import { type StoredMessage } from '../src/services/messages/StoredMessage.interface';
+import type { LoggerService } from '../src/services/logging/LoggerService';
 
 describe('RepositoryMessageService', () => {
   it('links chat and user when adding a message', async () => {
@@ -22,11 +23,22 @@ describe('RepositoryMessageService', () => {
       link: vi.fn(),
     } as unknown as ChatUserRepository;
 
+    const loggerService: LoggerService = {
+      createLogger: () => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        child: vi.fn(),
+      }),
+    } as unknown as LoggerService;
+
     const service = new RepositoryMessageService(
       chatRepo,
       userRepo,
       messageRepo,
-      chatUserRepo
+      chatUserRepo,
+      loggerService
     );
 
     const message: StoredMessage = {
@@ -53,7 +65,16 @@ describe('RepositoryMessageService', () => {
       {} as unknown as ChatRepository,
       {} as unknown as UserRepository,
       messageRepo,
-      {} as unknown as ChatUserRepository
+      {} as unknown as ChatUserRepository,
+      {
+        createLogger: () => ({
+          debug: vi.fn(),
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          child: vi.fn(),
+        }),
+      } as unknown as LoggerService
     );
 
     await service.getMessages(1);

--- a/test/RepositorySummaryService.test.ts
+++ b/test/RepositorySummaryService.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { type SummaryRepository } from '../src/repositories/interfaces/SummaryRepository.interface';
 import { RepositorySummaryService } from '../src/services/summaries/RepositorySummaryService';
+import type { LoggerService } from '../src/services/logging/LoggerService';
 
 describe('RepositorySummaryService', () => {
   it('getSummary calls findById', async () => {
@@ -11,7 +12,15 @@ describe('RepositorySummaryService', () => {
       clearByChatId: vi.fn(),
     } as unknown as SummaryRepository;
 
-    const service = new RepositorySummaryService(summaryRepo);
+    const service = new RepositorySummaryService(summaryRepo, {
+      createLogger: () => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        child: vi.fn(),
+      }),
+    } as unknown as LoggerService);
 
     await service.getSummary(123);
 
@@ -25,7 +34,15 @@ describe('RepositorySummaryService', () => {
       clearByChatId: vi.fn(),
     } as unknown as SummaryRepository;
 
-    const service = new RepositorySummaryService(summaryRepo);
+    const service = new RepositorySummaryService(summaryRepo, {
+      createLogger: () => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        child: vi.fn(),
+      }),
+    } as unknown as LoggerService);
 
     await service.setSummary(123, 'summary');
 
@@ -39,7 +56,15 @@ describe('RepositorySummaryService', () => {
       clearByChatId: vi.fn(),
     } as unknown as SummaryRepository;
 
-    const service = new RepositorySummaryService(summaryRepo);
+    const service = new RepositorySummaryService(summaryRepo, {
+      createLogger: () => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        child: vi.fn(),
+      }),
+    } as unknown as LoggerService);
 
     await service.clearSummary(123);
 

--- a/test/TriggerPipeline.test.ts
+++ b/test/TriggerPipeline.test.ts
@@ -14,15 +14,28 @@ import {
   type Trigger,
   TriggerContext,
 } from '../src/triggers/Trigger.interface';
+import type { LoggerService } from '../src/services/logging/LoggerService';
 
 describe('TriggerPipeline', () => {
   const env = {
     getBotName: () => 'bot',
     getDialogueTimeoutMs: () => 0,
   } as any;
+  const loggerService: LoggerService = {
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(),
+    }),
+  } as unknown as LoggerService;
 
   it('returns result when mention trigger matches', async () => {
-    const dialogue: DialogueManager = new DefaultDialogueManager(env);
+    const dialogue: DialogueManager = new DefaultDialogueManager(
+      env,
+      loggerService
+    );
     const pipeline: TriggerPipeline = new DefaultTriggerPipeline(
       env,
       {
@@ -49,7 +62,10 @@ describe('TriggerPipeline', () => {
     const interestChecker: InterestChecker = {
       check: vi.fn().mockResolvedValue(null),
     };
-    const dialogue: DialogueManager = new DefaultDialogueManager(env);
+    const dialogue: DialogueManager = new DefaultDialogueManager(
+      env,
+      loggerService
+    );
     const pipeline: TriggerPipeline = new DefaultTriggerPipeline(
       env,
       interestChecker,
@@ -77,7 +93,10 @@ describe('TriggerPipeline', () => {
         return result;
       },
     };
-    const dialogue: DialogueManager = new DefaultDialogueManager(env);
+    const dialogue: DialogueManager = new DefaultDialogueManager(
+      env,
+      loggerService
+    );
     const pipeline: TriggerPipeline = new DefaultTriggerPipeline(
       env,
       interestChecker,
@@ -107,7 +126,10 @@ describe('TriggerPipeline', () => {
         .fn()
         .mockResolvedValue({ messageId: '1', message: 'hi', why: 'because' }),
     };
-    const dialogue: DialogueManager = new DefaultDialogueManager(env);
+    const dialogue: DialogueManager = new DefaultDialogueManager(
+      env,
+      loggerService
+    );
     const pipeline = new DefaultTriggerPipeline(
       env,
       interestChecker,
@@ -136,7 +158,10 @@ describe('TriggerPipeline', () => {
     const interestChecker: InterestChecker = {
       check: vi.fn().mockRejectedValue(new Error('fail')),
     };
-    const dialogue: DialogueManager = new DefaultDialogueManager(env);
+    const dialogue: DialogueManager = new DefaultDialogueManager(
+      env,
+      loggerService
+    );
     const pipeline: TriggerPipeline = new DefaultTriggerPipeline(
       env,
       interestChecker,
@@ -162,7 +187,10 @@ describe('TriggerPipeline', () => {
         why: 'because',
       }),
     };
-    const dialogue: DialogueManager = new DefaultDialogueManager(env);
+    const dialogue: DialogueManager = new DefaultDialogueManager(
+      env,
+      loggerService
+    );
     const pipeline: TriggerPipeline = new DefaultTriggerPipeline(
       env,
       interestChecker,
@@ -187,7 +215,10 @@ describe('TriggerPipeline', () => {
     const interestChecker: InterestChecker = {
       check: vi.fn().mockResolvedValue(null),
     };
-    const dialogue: DialogueManager = new DefaultDialogueManager(env);
+    const dialogue: DialogueManager = new DefaultDialogueManager(
+      env,
+      loggerService
+    );
     const pipeline: TriggerPipeline = new DefaultTriggerPipeline(
       env,
       interestChecker,

--- a/test/Triggers.test.ts
+++ b/test/Triggers.test.ts
@@ -1,5 +1,5 @@
 import type { Context } from 'telegraf';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { DefaultDialogueManager } from '../src/services/chat/DialogueManager';
 import { TestEnvService } from '../src/services/env/EnvService';
@@ -7,6 +7,18 @@ import { MentionTrigger } from '../src/triggers/MentionTrigger';
 import { NameTrigger } from '../src/triggers/NameTrigger';
 import { ReplyTrigger } from '../src/triggers/ReplyTrigger';
 import { TriggerContext } from '../src/triggers/Trigger.interface';
+import type { LoggerService } from '../src/services/logging/LoggerService';
+
+const createLoggerService = (): LoggerService =>
+  ({
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(),
+    }),
+  }) as unknown as LoggerService;
 
 describe('MentionTrigger', () => {
   const trigger = new MentionTrigger();
@@ -20,7 +32,7 @@ describe('MentionTrigger', () => {
     const res = await trigger.apply(
       telegrafCtx,
       ctx,
-      new DefaultDialogueManager(new TestEnvService())
+      new DefaultDialogueManager(new TestEnvService(), createLoggerService())
     );
     expect(res).not.toBeNull();
     expect(res?.replyToMessageId).toBeNull();
@@ -37,7 +49,7 @@ describe('MentionTrigger', () => {
     const res = await trigger.apply(
       telegrafCtx,
       ctx,
-      new DefaultDialogueManager(new TestEnvService())
+      new DefaultDialogueManager(new TestEnvService(), createLoggerService())
     );
     expect(res).toBeNull();
     expect(ctx.text).toBe('');
@@ -49,7 +61,7 @@ describe('MentionTrigger', () => {
     const res = await trigger.apply(
       telegrafCtx,
       ctx,
-      new DefaultDialogueManager(new TestEnvService())
+      new DefaultDialogueManager(new TestEnvService(), createLoggerService())
     );
     expect(res).toBeNull();
     expect(ctx.text).toBe('');
@@ -68,7 +80,7 @@ describe('NameTrigger', () => {
     const res = await trigger.apply(
       {} as unknown as Context,
       ctx,
-      new DefaultDialogueManager(new TestEnvService())
+      new DefaultDialogueManager(new TestEnvService(), createLoggerService())
     );
     expect(res).not.toBeNull();
     expect(ctx.text).toBe('how are you?');
@@ -83,7 +95,7 @@ describe('NameTrigger', () => {
     const res = await trigger.apply(
       {} as unknown as Context,
       ctx,
-      new DefaultDialogueManager(new TestEnvService())
+      new DefaultDialogueManager(new TestEnvService(), createLoggerService())
     );
     expect(res).toBeNull();
     expect(ctx.text).toBe('Hello Arkadius');
@@ -102,7 +114,7 @@ describe('ReplyTrigger', () => {
     const res = await trigger.apply(
       telegrafCtx,
       ctx,
-      new DefaultDialogueManager(new TestEnvService())
+      new DefaultDialogueManager(new TestEnvService(), createLoggerService())
     );
     expect(res).not.toBeNull();
   });
@@ -113,7 +125,7 @@ describe('ReplyTrigger', () => {
     const res = await trigger.apply(
       telegrafCtx,
       ctx,
-      new DefaultDialogueManager(new TestEnvService())
+      new DefaultDialogueManager(new TestEnvService(), createLoggerService())
     );
     expect(res).toBeNull();
   });


### PR DESCRIPTION
## Summary
- inject LoggerService across chat, AI, prompt, and summary services
- replace direct createPinoLogger usage with service-provided loggers
- update tests for new logger injection

## Testing
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a49d40447c83278076202ccc3f7e94