### PR TITLE
refactor logging to use centralized pino logger

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,10 @@ import http from 'node:http';
 
 import { TelegramBot } from './bot/TelegramBot';
 import { container } from './container';
-import { PinoLogger } from './services/logging/PinoLogger';
+import { PinoLoggerService } from './services/logging/LoggerService';
 
-const logger = new PinoLogger();
+const loggerService = new PinoLoggerService();
+const logger = loggerService.getLogger();
 const bot = container.get<TelegramBot>(TelegramBot);
 
 logger.info('Starting application');

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -6,7 +6,7 @@ import sqlite3 from 'sqlite3';
 import { container } from './container';
 import type { EnvService } from './services/env/EnvService';
 import { ENV_SERVICE_ID } from './services/env/EnvService';
-import { PinoLogger } from './services/logging/PinoLogger';
+import { PinoLoggerService } from './services/logging/LoggerService';
 import { parseDatabaseUrl } from './utils/database';
 
 interface Migration {
@@ -18,7 +18,8 @@ interface Migration {
 const envService = container.get<EnvService>(ENV_SERVICE_ID);
 const env = envService.env;
 const filename = parseDatabaseUrl(env.DATABASE_URL);
-const logger = new PinoLogger();
+const loggerService = new PinoLoggerService();
+const logger = loggerService.getLogger();
 
 function loadMigrations(dir = envService.getMigrationsDir()): Migration[] {
   logger.info({ dir }, 'Loading migrations from directory');

--- a/src/services/logging/LoggerService.ts
+++ b/src/services/logging/LoggerService.ts
@@ -14,7 +14,17 @@ export const LOGGER_SERVICE_ID = Symbol.for(
 
 @injectable()
 export class PinoLoggerService implements LoggerService {
+  private readonly logger: Logger;
+
+  constructor() {
+    this.logger = new PinoLogger();
+  }
+
   createLogger(): Logger {
-    return new PinoLogger();
+    return this.logger;
+  }
+
+  getLogger(): Logger {
+    return this.logger;
   }
 }


### PR DESCRIPTION
## Summary
- use `PinoLoggerService` in app entrypoints instead of instantiating `PinoLogger` directly
- share a single logger instance via `PinoLoggerService`

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a5c404e450832791046404fe8b19aa