### PR TITLE
Refactor logging service into factory

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -68,8 +68,8 @@ import {
   INTEREST_CHECKER_ID,
 } from './services/interest/InterestChecker';
 import {
-  LOGGER_SERVICE_ID,
-  PinoLoggerService,
+  LOGGER_FACTORY_ID,
+  PinoLoggerFactory,
 } from './services/logging/LoggerService';
 import {
   INTEREST_MESSAGE_STORE_ID,
@@ -97,7 +97,7 @@ container
   .to(EnvServiceImpl)
   .inSingletonScope();
 
-container.bind(LOGGER_SERVICE_ID).to(PinoLoggerService).inSingletonScope();
+container.bind(LOGGER_FACTORY_ID).to(PinoLoggerFactory).inSingletonScope();
 
 container.bind(PROMPT_SERVICE_ID).to(FilePromptService).inSingletonScope();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,10 @@ import http from 'node:http';
 
 import { TelegramBot } from './bot/TelegramBot';
 import { container } from './container';
-import { PinoLoggerService } from './services/logging/LoggerService';
+import { PinoLoggerFactory } from './services/logging/LoggerService';
 
-const loggerService = new PinoLoggerService();
-const logger = loggerService.getLogger();
+const loggerFactory = new PinoLoggerFactory();
+const logger = loggerFactory.create('index');
 const bot = container.get<TelegramBot>(TelegramBot);
 
 logger.info('Starting application');

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -6,7 +6,7 @@ import sqlite3 from 'sqlite3';
 import { container } from './container';
 import type { EnvService } from './services/env/EnvService';
 import { ENV_SERVICE_ID } from './services/env/EnvService';
-import { PinoLoggerService } from './services/logging/LoggerService';
+import { PinoLoggerFactory } from './services/logging/LoggerService';
 import { parseDatabaseUrl } from './utils/database';
 
 interface Migration {
@@ -18,8 +18,8 @@ interface Migration {
 const envService = container.get<EnvService>(ENV_SERVICE_ID);
 const env = envService.env;
 const filename = parseDatabaseUrl(env.DATABASE_URL);
-const loggerService = new PinoLoggerService();
-const logger = loggerService.getLogger();
+const loggerFactory = new PinoLoggerFactory();
+const logger = loggerFactory.create('migrate');
 
 function loadMigrations(dir = envService.getMigrationsDir()): Migration[] {
   logger.info({ dir }, 'Loading migrations from directory');

--- a/src/services/ai/ChatGPTService.ts
+++ b/src/services/ai/ChatGPTService.ts
@@ -8,8 +8,8 @@ import { TriggerReason } from '../../triggers/Trigger.interface';
 import { ENV_SERVICE_ID, EnvService } from '../env/EnvService';
 import type Logger from '../logging/Logger.interface';
 import {
-  LOGGER_SERVICE_ID,
-  type LoggerService,
+  LOGGER_FACTORY_ID,
+  type LoggerFactory,
 } from '../logging/LoggerService';
 import {
   PROMPT_SERVICE_ID,
@@ -28,7 +28,7 @@ export class ChatGPTService implements AIService {
   constructor(
     @inject(ENV_SERVICE_ID) private readonly envService: EnvService,
     @inject(PROMPT_SERVICE_ID) private readonly prompts: PromptService,
-    @inject(LOGGER_SERVICE_ID) private loggerService: LoggerService
+    @inject(LOGGER_FACTORY_ID) private loggerFactory: LoggerFactory
   ) {
     const env = this.envService.env;
     this.openai = new OpenAI({ apiKey: env.OPENAI_API_KEY });
@@ -36,7 +36,7 @@ export class ChatGPTService implements AIService {
     this.askModel = models.ask;
     this.summaryModel = models.summary;
     this.interestModel = models.interest;
-    this.logger = this.loggerService.createLogger();
+    this.logger = this.loggerFactory.create('ChatGPTService');
     this.logger.debug('ChatGPTService initialized');
   }
 

--- a/src/services/chat/ChatMemory.ts
+++ b/src/services/chat/ChatMemory.ts
@@ -3,8 +3,8 @@ import { inject, injectable } from 'inversify';
 import { ChatMessage } from '../ai/AIService.interface';
 import type Logger from '../logging/Logger.interface';
 import {
-  LOGGER_SERVICE_ID,
-  type LoggerService,
+  LOGGER_FACTORY_ID,
+  type LoggerFactory,
 } from '../logging/LoggerService';
 import {
   INTEREST_MESSAGE_STORE_ID,
@@ -35,9 +35,9 @@ export class ChatMemory {
     private localStore: InterestMessageStore,
     private chatId: number,
     private limit: number,
-    private loggerService: LoggerService
+    private loggerFactory: LoggerFactory
   ) {
-    this.logger = this.loggerService.createLogger();
+    this.logger = this.loggerFactory.create('ChatMemory');
   }
 
   public async addMessage(message: StoredMessage): Promise<void> {
@@ -87,9 +87,9 @@ export class ChatMemoryManager {
     @inject(CHAT_RESET_SERVICE_ID) private resetService: ChatResetService,
     @inject(INTEREST_MESSAGE_STORE_ID) private localStore: InterestMessageStore,
     @inject(CHAT_CONFIG_SERVICE_ID) private config: ChatConfigService,
-    @inject(LOGGER_SERVICE_ID) private loggerService: LoggerService
+    @inject(LOGGER_FACTORY_ID) private loggerFactory: LoggerFactory
   ) {
-    this.logger = this.loggerService.createLogger();
+    this.logger = this.loggerFactory.create('ChatMemoryManager');
   }
 
   public async get(chatId: number): Promise<ChatMemory> {
@@ -101,7 +101,7 @@ export class ChatMemoryManager {
       this.localStore,
       chatId,
       historyLimit,
-      this.loggerService
+      this.loggerFactory
     );
   }
 

--- a/src/services/chat/DefaultChatResetService.ts
+++ b/src/services/chat/DefaultChatResetService.ts
@@ -2,8 +2,8 @@ import { inject, injectable } from 'inversify';
 
 import type Logger from '../logging/Logger.interface';
 import {
-  LOGGER_SERVICE_ID,
-  type LoggerService,
+  LOGGER_FACTORY_ID,
+  type LoggerFactory,
 } from '../logging/LoggerService';
 import {
   MESSAGE_SERVICE_ID,
@@ -21,9 +21,9 @@ export class DefaultChatResetService implements ChatResetService {
   constructor(
     @inject(MESSAGE_SERVICE_ID) private messages: MessageService,
     @inject(SUMMARY_SERVICE_ID) private summaries: SummaryService,
-    @inject(LOGGER_SERVICE_ID) private loggerService: LoggerService
+    @inject(LOGGER_FACTORY_ID) private loggerFactory: LoggerFactory
   ) {
-    this.logger = this.loggerService.createLogger();
+    this.logger = this.loggerFactory.create('DefaultChatResetService');
   }
 
   async reset(chatId: number): Promise<void> {

--- a/src/services/chat/DialogueManager.ts
+++ b/src/services/chat/DialogueManager.ts
@@ -4,8 +4,8 @@ import { inject, injectable } from 'inversify';
 import { ENV_SERVICE_ID, type EnvService } from '../env/EnvService';
 import type Logger from '../logging/Logger.interface';
 import {
-  LOGGER_SERVICE_ID,
-  type LoggerService,
+  LOGGER_FACTORY_ID,
+  type LoggerFactory,
 } from '../logging/LoggerService';
 
 export interface DialogueManager {
@@ -26,10 +26,10 @@ export class DefaultDialogueManager implements DialogueManager {
 
   constructor(
     @inject(ENV_SERVICE_ID) envService: EnvService,
-    @inject(LOGGER_SERVICE_ID) private loggerService: LoggerService
+    @inject(LOGGER_FACTORY_ID) private loggerFactory: LoggerFactory
   ) {
     this.timeoutMs = envService.getDialogueTimeoutMs();
-    this.logger = this.loggerService.createLogger();
+    this.logger = this.loggerFactory.create('DefaultDialogueManager');
   }
 
   start(chatId: number): void {

--- a/src/services/chat/HistorySummarizer.ts
+++ b/src/services/chat/HistorySummarizer.ts
@@ -12,8 +12,8 @@ import {
 } from '../ai/AIService.interface';
 import type Logger from '../logging/Logger.interface';
 import {
-  LOGGER_SERVICE_ID,
-  type LoggerService,
+  LOGGER_FACTORY_ID,
+  type LoggerFactory,
 } from '../logging/LoggerService';
 import {
   MESSAGE_SERVICE_ID,
@@ -45,9 +45,9 @@ export class DefaultHistorySummarizer implements HistorySummarizer {
     @inject(SUMMARY_SERVICE_ID) private summaries: SummaryService,
     @inject(MESSAGE_SERVICE_ID) private messages: MessageService,
     @inject(USER_REPOSITORY_ID) private users: UserRepository,
-    @inject(LOGGER_SERVICE_ID) private loggerService: LoggerService
+    @inject(LOGGER_FACTORY_ID) private loggerFactory: LoggerFactory
   ) {
-    this.logger = this.loggerService.createLogger();
+    this.logger = this.loggerFactory.create('DefaultHistorySummarizer');
   }
 
   async summarize(

--- a/src/services/logging/LoggerService.ts
+++ b/src/services/logging/LoggerService.ts
@@ -1,30 +1,27 @@
 import type { ServiceIdentifier } from 'inversify';
 import { injectable } from 'inversify';
+import pino, { type Logger as Pino } from 'pino';
 
 import type Logger from './Logger.interface';
 import { PinoLogger } from './PinoLogger';
 
-export interface LoggerService {
-  createLogger(): Logger;
+export interface LoggerFactory {
+  create(serviceName: string): Logger;
 }
 
-export const LOGGER_SERVICE_ID = Symbol.for(
-  'LoggerService'
-) as ServiceIdentifier<LoggerService>;
+export const LOGGER_FACTORY_ID = Symbol.for(
+  'LoggerFactory'
+) as ServiceIdentifier<LoggerFactory>;
 
 @injectable()
-export class PinoLoggerService implements LoggerService {
-  private readonly logger: Logger;
+export class PinoLoggerFactory implements LoggerFactory {
+  private readonly root: Pino;
 
   constructor() {
-    this.logger = new PinoLogger();
+    this.root = pino();
   }
 
-  createLogger(): Logger {
-    return this.logger;
-  }
-
-  getLogger(): Logger {
-    return this.logger;
+  create(serviceName: string): Logger {
+    return new PinoLogger(this.root.child({ service: serviceName }));
   }
 }

--- a/src/services/messages/RepositoryMessageService.ts
+++ b/src/services/messages/RepositoryMessageService.ts
@@ -19,8 +19,8 @@ import {
 import type { ChatMessage } from '../ai/AIService.interface';
 import type Logger from '../logging/Logger.interface';
 import {
-  LOGGER_SERVICE_ID,
-  type LoggerService,
+  LOGGER_FACTORY_ID,
+  type LoggerFactory,
 } from '../logging/LoggerService';
 import { MessageService } from './MessageService.interface';
 import { StoredMessage } from './StoredMessage.interface';
@@ -33,9 +33,9 @@ export class RepositoryMessageService implements MessageService {
     @inject(USER_REPOSITORY_ID) private userRepo: UserRepository,
     @inject(MESSAGE_REPOSITORY_ID) private messageRepo: MessageRepository,
     @inject(CHAT_USER_REPOSITORY_ID) private chatUserRepo: ChatUserRepository,
-    @inject(LOGGER_SERVICE_ID) private loggerService: LoggerService
+    @inject(LOGGER_FACTORY_ID) private loggerFactory: LoggerFactory
   ) {
-    this.logger = this.loggerService.createLogger();
+    this.logger = this.loggerFactory.create('RepositoryMessageService');
   }
 
   async addMessage(message: StoredMessage): Promise<void> {

--- a/src/services/prompts/FilePromptService.ts
+++ b/src/services/prompts/FilePromptService.ts
@@ -5,8 +5,8 @@ import { createLazy } from '../../utils/lazy';
 import { ENV_SERVICE_ID, EnvService } from '../env/EnvService';
 import type Logger from '../logging/Logger.interface';
 import {
-  LOGGER_SERVICE_ID,
-  type LoggerService,
+  LOGGER_FACTORY_ID,
+  type LoggerFactory,
 } from '../logging/LoggerService';
 import { PromptService } from './PromptService.interface';
 
@@ -26,10 +26,10 @@ export class FilePromptService implements PromptService {
 
   constructor(
     @inject(ENV_SERVICE_ID) envService: EnvService,
-    @inject(LOGGER_SERVICE_ID) private loggerService: LoggerService
+    @inject(LOGGER_FACTORY_ID) private loggerFactory: LoggerFactory
   ) {
     const files = envService.getPromptFiles();
-    this.logger = this.loggerService.createLogger();
+    this.logger = this.loggerFactory.create('FilePromptService');
     this.persona = createLazy(async () => {
       this.logger.debug('Loading persona file');
       return readFile(files.persona, 'utf-8');

--- a/src/services/summaries/RepositorySummaryService.ts
+++ b/src/services/summaries/RepositorySummaryService.ts
@@ -6,8 +6,8 @@ import {
 } from '../../repositories/interfaces/SummaryRepository.interface';
 import type Logger from '../logging/Logger.interface';
 import {
-  LOGGER_SERVICE_ID,
-  type LoggerService,
+  LOGGER_FACTORY_ID,
+  type LoggerFactory,
 } from '../logging/LoggerService';
 import { SummaryService } from './SummaryService.interface';
 
@@ -16,9 +16,9 @@ export class RepositorySummaryService implements SummaryService {
   private readonly logger: Logger;
   constructor(
     @inject(SUMMARY_REPOSITORY_ID) private summaryRepo: SummaryRepository,
-    @inject(LOGGER_SERVICE_ID) private loggerService: LoggerService
+    @inject(LOGGER_FACTORY_ID) private loggerFactory: LoggerFactory
   ) {
-    this.logger = this.loggerService.createLogger();
+    this.logger = this.loggerFactory.create('RepositorySummaryService');
   }
 
   async getSummary(chatId: number): Promise<string> {

--- a/test/ChatGPTService.test.ts
+++ b/test/ChatGPTService.test.ts
@@ -5,13 +5,13 @@ import type { ChatMessage } from '../src/services/ai/AIService';
 import type { ChatGPTService as ChatGPTServiceType } from '../src/services/ai/ChatGPTService';
 import { TestEnvService } from '../src/services/env/EnvService';
 import type { PromptService } from '../src/services/prompts/PromptService';
-import type { LoggerService } from '../src/services/logging/LoggerService';
+import type { LoggerFactory } from '../src/services/logging/LoggerService';
 
 interface ChatGPTServiceConstructor {
   new (
     env: TestEnvService,
     prompts: PromptService,
-    logger: LoggerService
+    logger: LoggerFactory
   ): ChatGPTServiceType;
 }
 
@@ -22,7 +22,7 @@ describe('ChatGPTService', () => {
   let prompts: Record<string, unknown>;
   let env: TestEnvService;
   let triggerPrompt: ReturnType<typeof vi.fn>;
-  let loggerService: LoggerService;
+  let loggerFactory: LoggerFactory;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -57,20 +57,20 @@ describe('ChatGPTService', () => {
     };
 
     env = new TestEnvService();
-    loggerService = {
-      createLogger: () => ({
+    loggerFactory = {
+      create: () => ({
         debug: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),
         error: vi.fn(),
         child: vi.fn(),
       }),
-    } as unknown as LoggerService;
+    } as unknown as LoggerFactory;
     ({ ChatGPTService } = await import('../src/services/ai/ChatGPTService'));
     service = new ChatGPTService(
       env,
       prompts as unknown as PromptService,
-      loggerService
+      loggerFactory
     );
   });
 
@@ -259,7 +259,7 @@ describe('ChatGPTService', () => {
     const service1 = new ChatGPTService(
       env1,
       prompts as unknown as PromptService,
-      loggerService
+      loggerFactory
     );
     await service1.ask([]);
     await new Promise<void>((resolve) => setTimeout(resolve, 0));
@@ -270,7 +270,7 @@ describe('ChatGPTService', () => {
     const service2 = new ChatGPTService(
       env2,
       prompts as unknown as PromptService,
-      loggerService
+      loggerFactory
     );
     await service2.ask([]);
     await new Promise<void>((resolve) => setTimeout(resolve, 0));

--- a/test/ChatMemory.test.ts
+++ b/test/ChatMemory.test.ts
@@ -12,18 +12,18 @@ import {
 } from '../src/services/messages/InterestMessageStore';
 import { MessageService } from '../src/services/messages/MessageService.interface';
 import { StoredMessage } from '../src/services/messages/StoredMessage.interface';
-import type { LoggerService } from '../src/services/logging/LoggerService';
+import type { LoggerFactory } from '../src/services/logging/LoggerService';
 
-const createLoggerService = (): LoggerService =>
+const createLoggerFactory = (): LoggerFactory =>
   ({
-    createLogger: () => ({
+    create: () => ({
       debug: vi.fn(),
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
       child: vi.fn(),
     }),
-  }) as unknown as LoggerService;
+  }) as unknown as LoggerFactory;
 
 class FakeHistorySummarizer implements HistorySummarizer {
   summarize = vi.fn(async () => false);
@@ -79,7 +79,7 @@ describe('ChatMemory', () => {
       localStore,
       1,
       2,
-      createLoggerService()
+      createLoggerFactory()
     );
   });
 
@@ -198,7 +198,7 @@ describe('ChatMemoryManager', () => {
       new DummyResetService(),
       new DummyInterestMessageStore(),
       config,
-      createLoggerService()
+      createLoggerFactory()
     );
     const mem = await manager.get(5);
     await mem.addMessage({ chatId: 5, role: 'user', content: 'hi' });
@@ -219,7 +219,7 @@ describe('ChatMemoryManager', () => {
       reset,
       local,
       new DummyChatConfigService(2),
-      createLoggerService()
+      createLoggerFactory()
     );
     await manager.reset(7);
     expect(reset.reset).toHaveBeenCalledWith(7);

--- a/test/ChatResetService.test.ts
+++ b/test/ChatResetService.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { MessageService } from '../src/services/messages/MessageService.interface';
 import type { SummaryService } from '../src/services/summaries/SummaryService.interface';
-import type { LoggerService } from '../src/services/logging/LoggerService';
+import type { LoggerFactory } from '../src/services/logging/LoggerService';
 import { DefaultChatResetService } from '../src/services/chat/DefaultChatResetService';
 
 describe('DefaultChatResetService', () => {
@@ -22,13 +22,13 @@ describe('DefaultChatResetService', () => {
     error: vi.fn(),
     child: vi.fn(),
   };
-  const loggerService: LoggerService = {
-    createLogger: () => logger,
-  } as unknown as LoggerService;
+  const loggerFactory: LoggerFactory = {
+    create: () => logger,
+  } as unknown as LoggerFactory;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    service = new DefaultChatResetService(messages, summaries, loggerService);
+    service = new DefaultChatResetService(messages, summaries, loggerFactory);
   });
 
   it('clears messages, summary and logs reset', async () => {

--- a/test/DialogueManager.test.ts
+++ b/test/DialogueManager.test.ts
@@ -5,7 +5,7 @@ import {
   type DialogueManager,
 } from '../src/services/chat/DialogueManager';
 import { TestEnvService } from '../src/services/env/EnvService';
-import type { LoggerService } from '../src/services/logging/LoggerService';
+import type { LoggerFactory } from '../src/services/logging/LoggerService';
 
 describe('DialogueManager', () => {
   beforeEach(() => {
@@ -15,16 +15,16 @@ describe('DialogueManager', () => {
   it('deactivates after timeout', () => {
     const env = new TestEnvService();
     vi.spyOn(env, 'getDialogueTimeoutMs').mockReturnValue(1000);
-    const loggerService: LoggerService = {
-      createLogger: () => ({
+    const loggerFactory: LoggerFactory = {
+      create: () => ({
         debug: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),
         error: vi.fn(),
         child: vi.fn(),
       }),
-    } as unknown as LoggerService;
-    const dm: DialogueManager = new DefaultDialogueManager(env, loggerService);
+    } as unknown as LoggerFactory;
+    const dm: DialogueManager = new DefaultDialogueManager(env, loggerFactory);
     dm.start(1);
     expect(dm.isActive(1)).toBe(true);
     vi.advanceTimersByTime(1000);
@@ -34,16 +34,16 @@ describe('DialogueManager', () => {
   it('extend resets timer', () => {
     const env = new TestEnvService();
     vi.spyOn(env, 'getDialogueTimeoutMs').mockReturnValue(1000);
-    const loggerService: LoggerService = {
-      createLogger: () => ({
+    const loggerFactory: LoggerFactory = {
+      create: () => ({
         debug: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),
         error: vi.fn(),
         child: vi.fn(),
       }),
-    } as unknown as LoggerService;
-    const dm: DialogueManager = new DefaultDialogueManager(env, loggerService);
+    } as unknown as LoggerFactory;
+    const dm: DialogueManager = new DefaultDialogueManager(env, loggerFactory);
     dm.start(1);
     vi.advanceTimersByTime(900);
     dm.extend(1);

--- a/test/HistorySummarizer.test.ts
+++ b/test/HistorySummarizer.test.ts
@@ -11,7 +11,7 @@ import type {
 import { DefaultHistorySummarizer } from '../src/services/chat/HistorySummarizer';
 import type { MessageService } from '../src/services/messages/MessageService.interface';
 import type { SummaryService } from '../src/services/summaries/SummaryService.interface';
-import type { LoggerService } from '../src/services/logging/LoggerService';
+import type { LoggerFactory } from '../src/services/logging/LoggerService';
 
 class MockAIService implements AIService {
   summarize = vi.fn(async () => 'new summary');
@@ -87,15 +87,15 @@ describe('HistorySummarizer', () => {
   let summaries: MockSummaryService;
   let summarizer: DefaultHistorySummarizer;
   let users: MockUserRepository;
-  const loggerService: LoggerService = {
-    createLogger: () => ({
+  const loggerFactory: LoggerFactory = {
+    create: () => ({
       debug: vi.fn(),
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
       child: vi.fn(),
     }),
-  } as unknown as LoggerService;
+  } as unknown as LoggerFactory;
 
   beforeEach(() => {
     ai = new MockAIService();
@@ -109,7 +109,7 @@ describe('HistorySummarizer', () => {
       summaries,
       messages,
       users,
-      loggerService
+      loggerFactory
     );
   });
 

--- a/test/InterestTrigger.test.ts
+++ b/test/InterestTrigger.test.ts
@@ -8,7 +8,7 @@ import {
 import { InterestChecker } from '../src/services/interest/InterestChecker';
 import { InterestTrigger } from '../src/triggers/InterestTrigger';
 import { TriggerContext } from '../src/triggers/Trigger.interface';
-import type { LoggerService } from '../src/services/logging/LoggerService';
+import type { LoggerFactory } from '../src/services/logging/LoggerService';
 
 class MockInterestChecker implements InterestChecker {
   public calls = 0;
@@ -35,18 +35,18 @@ class MockInterestChecker implements InterestChecker {
 }
 
 describe('InterestTrigger', () => {
-  const loggerService: LoggerService = {
-    createLogger: () => ({
+  const loggerFactory: LoggerFactory = {
+    create: () => ({
       debug: vi.fn(),
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
       child: vi.fn(),
     }),
-  } as unknown as LoggerService;
+  } as unknown as LoggerFactory;
   const dialogue: DialogueManager = new DefaultDialogueManager(
     { getDialogueTimeoutMs: () => 0 } as any,
-    loggerService
+    loggerFactory
   );
   const baseCtx: TriggerContext = { text: '', replyText: '', chatId: 1 };
 
@@ -106,7 +106,7 @@ describe('InterestTrigger', () => {
     const trigger = new InterestTrigger(checker);
     const activeDialogue: DialogueManager = new DefaultDialogueManager(
       { getDialogueTimeoutMs: () => 0 } as any,
-      loggerService
+      loggerFactory
     );
     activeDialogue.start(baseCtx.chatId);
     const res = await trigger.apply(

--- a/test/Logger.test.ts
+++ b/test/Logger.test.ts
@@ -19,10 +19,10 @@ describe('logger', () => {
     vi.resetModules();
     const { container } = await import('../src/container');
     const LoggerModule = await import('../src/services/logging/LoggerService');
-    const service = container.get<LoggerModule.LoggerService>(
-      LoggerModule.LOGGER_SERVICE_ID
+    const factory = container.get<LoggerModule.LoggerFactory>(
+      LoggerModule.LOGGER_FACTORY_ID
     );
-    const logger = service.createLogger();
+    const logger = factory.create('LoggerTest');
     logger.debug('debug');
     logger.info('info');
     logger.warn('warn');

--- a/test/PromptService.test.ts
+++ b/test/PromptService.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { TestEnvService } from '../src/services/env/EnvService';
 import type { FilePromptService } from '../src/services/prompts/FilePromptService';
-import type { LoggerService } from '../src/services/logging/LoggerService';
+import type { LoggerFactory } from '../src/services/logging/LoggerService';
 
 class TempEnvService extends TestEnvService {
   constructor(private dir: string) {
@@ -90,16 +90,16 @@ describe('FilePromptService', () => {
       '../src/services/prompts/FilePromptService'
     );
     const env = new TempEnvService(dir);
-    const loggerService: LoggerService = {
-      createLogger: () => ({
+    const loggerFactory: LoggerFactory = {
+      create: () => ({
         debug: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),
         error: vi.fn(),
         child: vi.fn(),
       }),
-    } as unknown as LoggerService;
-    service = new FilePromptService(env, loggerService);
+    } as unknown as LoggerFactory;
+    service = new FilePromptService(env, loggerFactory);
   });
 
   afterEach(() => {

--- a/test/RepositoryMessageService.test.ts
+++ b/test/RepositoryMessageService.test.ts
@@ -6,7 +6,7 @@ import { type MessageRepository } from '../src/repositories/interfaces/MessageRe
 import { type UserRepository } from '../src/repositories/interfaces/UserRepository.interface';
 import { RepositoryMessageService } from '../src/services/messages/RepositoryMessageService';
 import { type StoredMessage } from '../src/services/messages/StoredMessage.interface';
-import type { LoggerService } from '../src/services/logging/LoggerService';
+import type { LoggerFactory } from '../src/services/logging/LoggerService';
 
 describe('RepositoryMessageService', () => {
   it('links chat and user when adding a message', async () => {
@@ -23,22 +23,22 @@ describe('RepositoryMessageService', () => {
       link: vi.fn(),
     } as unknown as ChatUserRepository;
 
-    const loggerService: LoggerService = {
-      createLogger: () => ({
+    const loggerFactory: LoggerFactory = {
+      create: () => ({
         debug: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),
         error: vi.fn(),
         child: vi.fn(),
       }),
-    } as unknown as LoggerService;
+    } as unknown as LoggerFactory;
 
     const service = new RepositoryMessageService(
       chatRepo,
       userRepo,
       messageRepo,
       chatUserRepo,
-      loggerService
+      loggerFactory
     );
 
     const message: StoredMessage = {
@@ -67,14 +67,14 @@ describe('RepositoryMessageService', () => {
       messageRepo,
       {} as unknown as ChatUserRepository,
       {
-        createLogger: () => ({
+        create: () => ({
           debug: vi.fn(),
           info: vi.fn(),
           warn: vi.fn(),
           error: vi.fn(),
           child: vi.fn(),
         }),
-      } as unknown as LoggerService
+      } as unknown as LoggerFactory
     );
 
     await service.getMessages(1);

--- a/test/RepositorySummaryService.test.ts
+++ b/test/RepositorySummaryService.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { type SummaryRepository } from '../src/repositories/interfaces/SummaryRepository.interface';
 import { RepositorySummaryService } from '../src/services/summaries/RepositorySummaryService';
-import type { LoggerService } from '../src/services/logging/LoggerService';
+import type { LoggerFactory } from '../src/services/logging/LoggerService';
 
 describe('RepositorySummaryService', () => {
   it('getSummary calls findById', async () => {
@@ -13,14 +13,14 @@ describe('RepositorySummaryService', () => {
     } as unknown as SummaryRepository;
 
     const service = new RepositorySummaryService(summaryRepo, {
-      createLogger: () => ({
+      create: () => ({
         debug: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),
         error: vi.fn(),
         child: vi.fn(),
       }),
-    } as unknown as LoggerService);
+    } as unknown as LoggerFactory);
 
     await service.getSummary(123);
 
@@ -35,14 +35,14 @@ describe('RepositorySummaryService', () => {
     } as unknown as SummaryRepository;
 
     const service = new RepositorySummaryService(summaryRepo, {
-      createLogger: () => ({
+      create: () => ({
         debug: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),
         error: vi.fn(),
         child: vi.fn(),
       }),
-    } as unknown as LoggerService);
+    } as unknown as LoggerFactory);
 
     await service.setSummary(123, 'summary');
 
@@ -57,14 +57,14 @@ describe('RepositorySummaryService', () => {
     } as unknown as SummaryRepository;
 
     const service = new RepositorySummaryService(summaryRepo, {
-      createLogger: () => ({
+      create: () => ({
         debug: vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),
         error: vi.fn(),
         child: vi.fn(),
       }),
-    } as unknown as LoggerService);
+    } as unknown as LoggerFactory);
 
     await service.clearSummary(123);
 

--- a/test/TriggerPipeline.test.ts
+++ b/test/TriggerPipeline.test.ts
@@ -14,27 +14,27 @@ import {
   type Trigger,
   TriggerContext,
 } from '../src/triggers/Trigger.interface';
-import type { LoggerService } from '../src/services/logging/LoggerService';
+import type { LoggerFactory } from '../src/services/logging/LoggerService';
 
 describe('TriggerPipeline', () => {
   const env = {
     getBotName: () => 'bot',
     getDialogueTimeoutMs: () => 0,
   } as any;
-  const loggerService: LoggerService = {
-    createLogger: () => ({
+  const loggerFactory: LoggerFactory = {
+    create: () => ({
       debug: vi.fn(),
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
       child: vi.fn(),
     }),
-  } as unknown as LoggerService;
+  } as unknown as LoggerFactory;
 
   it('returns result when mention trigger matches', async () => {
     const dialogue: DialogueManager = new DefaultDialogueManager(
       env,
-      loggerService
+      loggerFactory
     );
     const pipeline: TriggerPipeline = new DefaultTriggerPipeline(
       env,
@@ -64,7 +64,7 @@ describe('TriggerPipeline', () => {
     };
     const dialogue: DialogueManager = new DefaultDialogueManager(
       env,
-      loggerService
+      loggerFactory
     );
     const pipeline: TriggerPipeline = new DefaultTriggerPipeline(
       env,
@@ -95,7 +95,7 @@ describe('TriggerPipeline', () => {
     };
     const dialogue: DialogueManager = new DefaultDialogueManager(
       env,
-      loggerService
+      loggerFactory
     );
     const pipeline: TriggerPipeline = new DefaultTriggerPipeline(
       env,
@@ -128,7 +128,7 @@ describe('TriggerPipeline', () => {
     };
     const dialogue: DialogueManager = new DefaultDialogueManager(
       env,
-      loggerService
+      loggerFactory
     );
     const pipeline = new DefaultTriggerPipeline(
       env,
@@ -160,7 +160,7 @@ describe('TriggerPipeline', () => {
     };
     const dialogue: DialogueManager = new DefaultDialogueManager(
       env,
-      loggerService
+      loggerFactory
     );
     const pipeline: TriggerPipeline = new DefaultTriggerPipeline(
       env,
@@ -189,7 +189,7 @@ describe('TriggerPipeline', () => {
     };
     const dialogue: DialogueManager = new DefaultDialogueManager(
       env,
-      loggerService
+      loggerFactory
     );
     const pipeline: TriggerPipeline = new DefaultTriggerPipeline(
       env,
@@ -217,7 +217,7 @@ describe('TriggerPipeline', () => {
     };
     const dialogue: DialogueManager = new DefaultDialogueManager(
       env,
-      loggerService
+      loggerFactory
     );
     const pipeline: TriggerPipeline = new DefaultTriggerPipeline(
       env,

--- a/test/Triggers.test.ts
+++ b/test/Triggers.test.ts
@@ -7,18 +7,18 @@ import { MentionTrigger } from '../src/triggers/MentionTrigger';
 import { NameTrigger } from '../src/triggers/NameTrigger';
 import { ReplyTrigger } from '../src/triggers/ReplyTrigger';
 import { TriggerContext } from '../src/triggers/Trigger.interface';
-import type { LoggerService } from '../src/services/logging/LoggerService';
+import type { LoggerFactory } from '../src/services/logging/LoggerService';
 
-const createLoggerService = (): LoggerService =>
+const createLoggerFactory = (): LoggerFactory =>
   ({
-    createLogger: () => ({
+    create: () => ({
       debug: vi.fn(),
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
       child: vi.fn(),
     }),
-  }) as unknown as LoggerService;
+  }) as unknown as LoggerFactory;
 
 describe('MentionTrigger', () => {
   const trigger = new MentionTrigger();
@@ -32,7 +32,7 @@ describe('MentionTrigger', () => {
     const res = await trigger.apply(
       telegrafCtx,
       ctx,
-      new DefaultDialogueManager(new TestEnvService(), createLoggerService())
+      new DefaultDialogueManager(new TestEnvService(), createLoggerFactory())
     );
     expect(res).not.toBeNull();
     expect(res?.replyToMessageId).toBeNull();
@@ -49,7 +49,7 @@ describe('MentionTrigger', () => {
     const res = await trigger.apply(
       telegrafCtx,
       ctx,
-      new DefaultDialogueManager(new TestEnvService(), createLoggerService())
+      new DefaultDialogueManager(new TestEnvService(), createLoggerFactory())
     );
     expect(res).toBeNull();
     expect(ctx.text).toBe('');
@@ -61,7 +61,7 @@ describe('MentionTrigger', () => {
     const res = await trigger.apply(
       telegrafCtx,
       ctx,
-      new DefaultDialogueManager(new TestEnvService(), createLoggerService())
+      new DefaultDialogueManager(new TestEnvService(), createLoggerFactory())
     );
     expect(res).toBeNull();
     expect(ctx.text).toBe('');
@@ -80,7 +80,7 @@ describe('NameTrigger', () => {
     const res = await trigger.apply(
       {} as unknown as Context,
       ctx,
-      new DefaultDialogueManager(new TestEnvService(), createLoggerService())
+      new DefaultDialogueManager(new TestEnvService(), createLoggerFactory())
     );
     expect(res).not.toBeNull();
     expect(ctx.text).toBe('how are you?');
@@ -95,7 +95,7 @@ describe('NameTrigger', () => {
     const res = await trigger.apply(
       {} as unknown as Context,
       ctx,
-      new DefaultDialogueManager(new TestEnvService(), createLoggerService())
+      new DefaultDialogueManager(new TestEnvService(), createLoggerFactory())
     );
     expect(res).toBeNull();
     expect(ctx.text).toBe('Hello Arkadius');
@@ -114,7 +114,7 @@ describe('ReplyTrigger', () => {
     const res = await trigger.apply(
       telegrafCtx,
       ctx,
-      new DefaultDialogueManager(new TestEnvService(), createLoggerService())
+      new DefaultDialogueManager(new TestEnvService(), createLoggerFactory())
     );
     expect(res).not.toBeNull();
   });
@@ -125,7 +125,7 @@ describe('ReplyTrigger', () => {
     const res = await trigger.apply(
       telegrafCtx,
       ctx,
-      new DefaultDialogueManager(new TestEnvService(), createLoggerService())
+      new DefaultDialogueManager(new TestEnvService(), createLoggerFactory())
     );
     expect(res).toBeNull();
   });


### PR DESCRIPTION
## Summary
- introduce `LoggerFactory` interface and `PinoLoggerFactory`
- bind logger factory in the container and update services/tests
- use per-service child loggers for clearer logging context

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a5d57c764c8327b0885ecd6179fa22