### PR TITLE
Log message counts in interest store

### DIFF
--- a/src/services/messages/InterestMessageStore.ts
+++ b/src/services/messages/InterestMessageStore.ts
@@ -1,6 +1,11 @@
-import type { ServiceIdentifier } from 'inversify';
+import { inject, injectable, type ServiceIdentifier } from 'inversify';
 
 import type { ChatMessage } from '../ai/AIService.interface';
+import type Logger from '../logging/Logger.interface';
+import {
+  LOGGER_FACTORY_ID,
+  type LoggerFactory,
+} from '../logging/LoggerFactory';
 import type { StoredMessage } from './StoredMessage.interface';
 
 export interface InterestMessageStore {
@@ -15,13 +20,25 @@ export const INTEREST_MESSAGE_STORE_ID = Symbol.for(
   'InterestMessageStore'
 ) as ServiceIdentifier<InterestMessageStore>;
 
+@injectable()
 export class InterestMessageStoreImpl implements InterestMessageStore {
+  private readonly logger: Logger;
   private readonly messages = new Map<number, StoredMessage[]>();
+
+  constructor(@inject(LOGGER_FACTORY_ID) loggerFactory: LoggerFactory) {
+    this.logger = loggerFactory.create('InterestMessageStore');
+  }
 
   addMessage(msg: StoredMessage): void {
     const chatMessages = this.messages.get(msg.chatId) ?? [];
+    const prevCount = chatMessages.length;
     chatMessages.push(msg);
     this.messages.set(msg.chatId, chatMessages);
+    const newCount = chatMessages.length;
+    this.logger.debug(
+      { chatId: msg.chatId, prevCount, newCount },
+      'Added message'
+    );
   }
 
   getMessages(chatId: number): ChatMessage[] {
@@ -38,6 +55,8 @@ export class InterestMessageStoreImpl implements InterestMessageStore {
   }
 
   clearMessages(chatId: number): void {
+    const prevCount = this.getCount(chatId);
     this.messages.delete(chatId);
+    this.logger.debug({ chatId, prevCount, newCount: 0 }, 'Cleared messages');
   }
 }

--- a/test/ChatMemory.test.ts
+++ b/test/ChatMemory.test.ts
@@ -34,6 +34,10 @@ class FakeMessageService
   extends InterestMessageStoreImpl
   implements MessageService
 {
+  constructor() {
+    super(createLoggerFactory());
+  }
+
   async addMessage(message: StoredMessage): Promise<void> {
     super.addMessage(message);
   }

--- a/test/InterestChecker.test.ts
+++ b/test/InterestChecker.test.ts
@@ -8,9 +8,21 @@ import {
   InterestMessageStoreImpl,
 } from '../src/services/messages/InterestMessageStore';
 import { SummaryService } from '../src/services/summaries/SummaryService.interface';
+import type { LoggerFactory } from '../src/services/logging/LoggerFactory';
 
 const interval = 2;
 const chatId = 1;
+
+const createLoggerFactory = (): LoggerFactory =>
+  ({
+    create: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(),
+    }),
+  }) as unknown as LoggerFactory;
 
 function createChecker(opts: {
   count: number;
@@ -125,7 +137,7 @@ describe('DefaultInterestChecker', () => {
   });
 
   it('clears stored messages after checking', async () => {
-    const store = new InterestMessageStoreImpl();
+    const store = new InterestMessageStoreImpl(createLoggerFactory());
     store.addMessage({ chatId, role: 'user', content: 'hi', messageId: 1 });
     const checker = new DefaultInterestChecker(
       store,


### PR DESCRIPTION
## Summary
- inject LoggerFactory into `InterestMessageStoreImpl`
- log previous and new message counts when adding or clearing messages
- adjust tests for new logger requirement

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a71e0111708327bede1cc4cfebf3c5