### PR TITLE
Add logging to SQLite database provider

### DIFF
--- a/src/repositories/DbProvider.ts
+++ b/src/repositories/DbProvider.ts
@@ -5,6 +5,11 @@ import { open } from 'sqlite';
 import sqlite3 from 'sqlite3';
 
 import { ENV_SERVICE_ID, EnvService } from '../services/env/EnvService';
+import type Logger from '../services/logging/Logger.interface';
+import {
+  LOGGER_FACTORY_ID,
+  type LoggerFactory,
+} from '../services/logging/LoggerFactory';
 import { parseDatabaseUrl } from '../utils/database';
 
 export interface DbProvider<T = unknown> {
@@ -17,10 +22,19 @@ export type SQLiteDbProvider = DbProvider<Database>;
 @injectable()
 export class SQLiteDbProviderImpl implements SQLiteDbProvider {
   private db: Promise<Database>;
+  private readonly logger: Logger;
 
-  constructor(@inject(ENV_SERVICE_ID) envService: EnvService) {
+  constructor(
+    @inject(ENV_SERVICE_ID) envService: EnvService,
+    @inject(LOGGER_FACTORY_ID) loggerFactory: LoggerFactory
+  ) {
+    this.logger = loggerFactory.create('SQLiteDbProviderImpl');
     const filename = parseDatabaseUrl(envService.env.DATABASE_URL);
-    this.db = open({ filename, driver: sqlite3.Database });
+    this.logger.info({ filename }, 'Opening SQLite database');
+    this.db = open({ filename, driver: sqlite3.Database }).catch((error) => {
+      this.logger.error({ filename, error }, 'Failed to open SQLite database');
+      throw error;
+    });
   }
 
   get(): Promise<Database> {
@@ -28,11 +42,18 @@ export class SQLiteDbProviderImpl implements SQLiteDbProvider {
   }
 
   async listTables(): Promise<string[]> {
-    const db = await this.db;
-    const rows = await db.all<{ name: string }[]>(
-      "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
-    );
-    return rows.map((r) => r.name);
+    try {
+      const db = await this.db;
+      const rows = await db.all<{ name: string }[]>(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+      );
+      const tables = rows.map((r) => r.name);
+      this.logger.info({ count: tables.length }, 'Enumerated database tables');
+      return tables;
+    } catch (error) {
+      this.logger.error({ error }, 'Failed to list database tables');
+      throw error;
+    }
   }
 }
 

--- a/test/sqliteRepositories.test.ts
+++ b/test/sqliteRepositories.test.ts
@@ -14,6 +14,23 @@ import { SQLiteSummaryRepository } from '../src/repositories/sqlite/SQLiteSummar
 import { SQLiteUserRepository } from '../src/repositories/sqlite/SQLiteUserRepository';
 import { TestEnvService } from '../src/services/env/EnvService';
 import { parseDatabaseUrl } from '../src/utils/database';
+import type { LoggerFactory } from '../src/services/logging/LoggerFactory';
+
+const createLoggerFactory = (): LoggerFactory =>
+  ({
+    create: () => {
+      const logger = {
+        debug() {},
+        info() {},
+        warn() {},
+        error() {},
+        child() {
+          return logger;
+        },
+      };
+      return logger;
+    },
+  }) as unknown as LoggerFactory;
 
 let chatRepo: SQLiteChatRepository;
 let userRepo: SQLiteUserRepository;
@@ -74,7 +91,7 @@ beforeEach(async () => {
       );
     `);
   await db.close();
-  const provider = new SQLiteDbProviderImpl(env);
+  const provider = new SQLiteDbProviderImpl(env, createLoggerFactory());
   chatRepo = new SQLiteChatRepository(provider);
   userRepo = new SQLiteUserRepository(provider);
   messageRepo = new SQLiteMessageRepository(provider);


### PR DESCRIPTION
## Summary
- inject LoggerFactory and log database path and table enumeration
- log connection and table enumeration failures
- adapt sqlite repository tests for logger injection

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a721846d908327ad675e2f51de91d4