### PR TITLE
feat: log chat responder metrics

### DIFF
--- a/src/services/chat/ChatResponder.ts
+++ b/src/services/chat/ChatResponder.ts
@@ -4,6 +4,11 @@ import { Context } from 'telegraf';
 
 import { TriggerReason } from '../../triggers/Trigger.interface';
 import { AI_SERVICE_ID, AIService } from '../ai/AIService.interface';
+import type Logger from '../logging/Logger.interface';
+import {
+  LOGGER_FACTORY_ID,
+  type LoggerFactory,
+} from '../logging/LoggerFactory';
 import { MessageFactory } from '../messages/MessageFactory';
 import {
   SUMMARY_SERVICE_ID,
@@ -25,11 +30,16 @@ export const CHAT_RESPONDER_ID = Symbol.for(
 
 @injectable()
 export class DefaultChatResponder implements ChatResponder {
+  private readonly logger: Logger;
+
   constructor(
     @inject(AI_SERVICE_ID) private ai: AIService,
     @inject(ChatMemoryManager) private memories: ChatMemoryManager,
-    @inject(SUMMARY_SERVICE_ID) private summaries: SummaryService
-  ) {}
+    @inject(SUMMARY_SERVICE_ID) private summaries: SummaryService,
+    @inject(LOGGER_FACTORY_ID) private loggerFactory: LoggerFactory
+  ) {
+    this.logger = this.loggerFactory.create('DefaultChatResponder');
+  }
 
   async generate(
     ctx: Context,
@@ -39,7 +49,18 @@ export class DefaultChatResponder implements ChatResponder {
     const memory = await this.memories.get(chatId);
     const history = await memory.getHistory();
     const summary = await this.summaries.getSummary(chatId);
+    const start = Date.now();
     const answer = await this.ai.ask(history, summary, triggerReason);
+    const responseTimeMs = Date.now() - start;
+    this.logger.debug(
+      {
+        chatId,
+        historyLength: history.length,
+        hasSummary: Boolean(summary),
+        responseTimeMs,
+      },
+      'Generated chat response'
+    );
     await memory.addMessage(MessageFactory.fromAssistant(ctx, answer));
     return answer;
   }

--- a/test/ChatResponder.test.ts
+++ b/test/ChatResponder.test.ts
@@ -1,5 +1,5 @@
 import type { Context } from 'telegraf';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type {
   AIService,
@@ -12,6 +12,7 @@ import {
 } from '../src/services/chat/ChatResponder';
 import type { SummaryService } from '../src/services/summaries/SummaryService.interface';
 import { TriggerReason } from '../src/triggers/Trigger.interface';
+import type { LoggerFactory } from '../src/services/logging/LoggerFactory';
 
 class MockAIService implements AIService {
   history: ChatMessage[] | undefined;
@@ -68,6 +69,17 @@ class MockSummaryService implements SummaryService {
   async setSummary(): Promise<void> {}
 }
 
+const createLoggerFactory = (): LoggerFactory =>
+  ({
+    create: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(),
+    }),
+  }) as unknown as LoggerFactory;
+
 describe('ChatResponder', () => {
   it('generates answer and stores assistant message', async () => {
     const ai = new MockAIService();
@@ -76,7 +88,8 @@ describe('ChatResponder', () => {
     const responder: ChatResponder = new DefaultChatResponder(
       ai,
       memories,
-      summaries
+      summaries,
+      createLoggerFactory()
     );
 
     const mem1 = await memories.get(1);
@@ -102,7 +115,8 @@ describe('ChatResponder', () => {
     const responder: ChatResponder = new DefaultChatResponder(
       ai,
       memories,
-      summaries
+      summaries,
+      createLoggerFactory()
     );
 
     const mem2 = await memories.get(1);
@@ -120,7 +134,8 @@ describe('ChatResponder', () => {
     const responder: ChatResponder = new DefaultChatResponder(
       ai,
       memories,
-      summaries
+      summaries,
+      createLoggerFactory()
     );
     const ctx = { me: 'bot', chat: { id: 1 } } as unknown as Context;
 


### PR DESCRIPTION
## Summary
- inject `LoggerFactory` into `DefaultChatResponder`
- log history length, summary presence, and AI response time in `generate`

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a72259f0dc8327a6c2c60f11a248d9