### PR TITLE
Log summarization result and message counts in ChatMemory

### DIFF
--- a/src/services/chat/ChatMemory.ts
+++ b/src/services/chat/ChatMemory.ts
@@ -70,6 +70,17 @@ export class ChatMemory {
     if (summarized) {
       await this.summarizer.assessUsers(this.chatId, history);
     }
+    const localStoreCount = this.localStore.getCount(this.chatId);
+    const removedCount = summarized ? history.length : 0;
+    this.logger.debug(
+      {
+        chatId: this.chatId,
+        summarized,
+        removedCount,
+        localStoreCount,
+      },
+      'Summarization result'
+    );
   }
 
   public getHistory(): Promise<ChatMessage[]> {


### PR DESCRIPTION
## Summary
- Log if chat history summarization occurred and how many messages were removed and stored locally

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a7227154c48327bd185461c7e34a65