### PR TITLE
Log chat reset counts

### DIFF
--- a/src/services/chat/DefaultChatResetService.ts
+++ b/src/services/chat/DefaultChatResetService.ts
@@ -28,7 +28,24 @@ export class DefaultChatResetService implements ChatResetService {
 
   async reset(chatId: number): Promise<void> {
     this.logger.debug({ chatId }, 'Resetting chat data');
-    await this.messages.clearMessages(chatId);
-    await this.summaries.clearSummary(chatId);
+
+    const [messageCount, summary] = await Promise.all([
+      this.messages.getCount(chatId),
+      this.summaries.getSummary(chatId),
+    ]);
+
+    await Promise.all([
+      this.messages.clearMessages(chatId),
+      this.summaries.clearSummary(chatId),
+    ]);
+
+    this.logger.info(
+      {
+        chatId,
+        messagesCleared: messageCount,
+        summariesCleared: summary ? 1 : 0,
+      },
+      'Cleared chat data'
+    );
   }
 }

--- a/test/ChatResetService.test.ts
+++ b/test/ChatResetService.test.ts
@@ -8,10 +8,12 @@ import { DefaultChatResetService } from '../src/services/chat/DefaultChatResetSe
 describe('DefaultChatResetService', () => {
   const messages = {
     clearMessages: vi.fn().mockResolvedValue(undefined),
+    getCount: vi.fn().mockResolvedValue(5),
   } as unknown as MessageService;
 
   const summaries = {
     clearSummary: vi.fn().mockResolvedValue(undefined),
+    getSummary: vi.fn().mockResolvedValue('foo'),
   } as unknown as SummaryService;
 
   let service: DefaultChatResetService;
@@ -34,6 +36,8 @@ describe('DefaultChatResetService', () => {
   it('clears messages, summary and logs reset', async () => {
     const chatId = 123;
     await service.reset(chatId);
+    expect(messages.getCount).toHaveBeenCalledWith(chatId);
+    expect(summaries.getSummary).toHaveBeenCalledWith(chatId);
     expect(messages.clearMessages).toHaveBeenCalledWith(chatId);
     expect(summaries.clearSummary).toHaveBeenCalledWith(chatId);
     expect(logger.debug).toHaveBeenCalledWith(
@@ -41,6 +45,14 @@ describe('DefaultChatResetService', () => {
         chatId,
       },
       'Resetting chat data'
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      {
+        chatId,
+        messagesCleared: 5,
+        summariesCleared: 1,
+      },
+      'Cleared chat data'
     );
   });
 });


### PR DESCRIPTION
## Summary
- log counts of cleared messages and summaries after reset
- test logging for chat reset counts

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a72268d76083278b3f9b49be0afc88