### PR TITLE
Inject logger into interest checker

### DIFF
--- a/src/services/interest/InterestChecker.ts
+++ b/src/services/interest/InterestChecker.ts
@@ -10,6 +10,11 @@ import {
   CHAT_CONFIG_SERVICE_ID,
   ChatConfigService,
 } from '../chat/ChatConfigService';
+import type Logger from '../logging/Logger.interface';
+import {
+  LOGGER_FACTORY_ID,
+  type LoggerFactory,
+} from '../logging/LoggerFactory';
 import {
   INTEREST_MESSAGE_STORE_ID,
   InterestMessageStore,
@@ -31,20 +36,26 @@ export const INTEREST_CHECKER_ID = Symbol.for(
 
 @injectable()
 export class DefaultInterestChecker implements InterestChecker {
+  private readonly logger: Logger;
+
   constructor(
     @inject(INTEREST_MESSAGE_STORE_ID)
     private interestMessageStore: InterestMessageStore,
     @inject(SUMMARY_SERVICE_ID) private summaries: SummaryService,
     @inject(AI_SERVICE_ID) private ai: AIService,
     @inject(CHAT_CONFIG_SERVICE_ID)
-    private chatConfig: ChatConfigService
-  ) {}
+    private chatConfig: ChatConfigService,
+    @inject(LOGGER_FACTORY_ID) loggerFactory: LoggerFactory
+  ) {
+    this.logger = loggerFactory.create('InterestChecker');
+  }
 
   async check(
     chatId: number
   ): Promise<{ messageId: string; message: string; why: string } | null> {
     const { interestInterval } = await this.chatConfig.getConfig(chatId);
     const count = this.interestMessageStore.getCount(chatId);
+    this.logger.debug({ chatId, interestInterval, count }, 'Checking interest');
     if (count < interestInterval) {
       return null;
     }
@@ -55,6 +66,10 @@ export class DefaultInterestChecker implements InterestChecker {
     this.interestMessageStore.clearMessages(chatId);
     const summary = (await this.summaries.getSummary(chatId)) ?? '';
     const result = await this.ai.checkInterest(history, summary);
+    this.logger.debug(
+      { chatId, result: result ? 'hit' : 'miss' },
+      'AI interest check result'
+    );
     if (!result) {
       return null;
     }

--- a/test/InterestChecker.test.ts
+++ b/test/InterestChecker.test.ts
@@ -59,7 +59,13 @@ function createChecker(opts: {
     setInterestInterval: vi.fn(),
   } as unknown as ChatConfigService;
   return {
-    checker: new DefaultInterestChecker(store, summaries, ai, chatConfig),
+    checker: new DefaultInterestChecker(
+      store,
+      summaries,
+      ai,
+      chatConfig,
+      createLoggerFactory()
+    ),
     store,
     summaries,
     ai,
@@ -153,7 +159,8 @@ describe('DefaultInterestChecker', () => {
           .mockResolvedValue({ chatId, historyLimit: 0, interestInterval: 1 }),
         setHistoryLimit: vi.fn(),
         setInterestInterval: vi.fn(),
-      } as unknown as ChatConfigService
+      } as unknown as ChatConfigService,
+      createLoggerFactory()
     );
 
     await checker.check(chatId);


### PR DESCRIPTION
## Summary
- inject LoggerFactory into InterestChecker
- log interest interval, message count, and AI hit/miss

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a722bb0cfc8327a01a6c07723f7283