### PR TITLE
Log message info in ReplyTrigger

### DIFF
--- a/src/triggers/ReplyTrigger.ts
+++ b/src/triggers/ReplyTrigger.ts
@@ -20,12 +20,22 @@ export class ReplyTrigger implements Trigger {
     _dialogue: DialogueManager
   ): Promise<TriggerResult | null> {
     const msg = ctx.message as
-      | { reply_to_message?: { from?: { username?: string } } }
+      | {
+          message_id?: number;
+          reply_to_message?: { from?: { username?: string } };
+        }
       | undefined;
     const reply = msg?.reply_to_message;
 
     if (reply?.from?.username === ctx.me) {
-      this.logger.debug({ chatId: context.chatId }, 'Reply trigger matched');
+      this.logger.debug(
+        {
+          chatId: context.chatId,
+          messageId: msg?.message_id,
+          username: ctx.from?.username,
+        },
+        'Reply trigger matched'
+      );
       return { replyToMessageId: null, reason: null };
     }
     return null;


### PR DESCRIPTION
## Summary
- include message id and sender username in ReplyTrigger debug log

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a722bfaaf4832790d9fd3922bddd93