### PR TITLE
Log interest trigger suppression reasons

### DIFF
--- a/src/triggers/InterestTrigger.ts
+++ b/src/triggers/InterestTrigger.ts
@@ -25,6 +25,10 @@ export class InterestTrigger implements Trigger {
     dialogue: DialogueManager
   ): Promise<TriggerResult | null> {
     if (dialogue.isActive(chatId)) {
+      this.logger.debug(
+        { chatId },
+        'Interest trigger suppressed because dialogue is active'
+      );
       return null;
     }
 
@@ -36,6 +40,10 @@ export class InterestTrigger implements Trigger {
         reason: { message: result.message, why: result.why },
       };
     }
+    this.logger.debug(
+      { chatId },
+      'Interest trigger suppressed because interest check returned null'
+    );
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- log interest trigger suppression when dialogue is active
- log when interest check returns null

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a722c1fc808327acd880e394b398aa