### PR TITLE
Configure Pino logger level from environment

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,12 @@ import http from 'node:http';
 
 import { TelegramBot } from './bot/TelegramBot';
 import { container } from './container';
+import type { EnvService } from './services/env/EnvService';
+import { ENV_SERVICE_ID } from './services/env/EnvService';
 import { PinoLoggerFactory } from './services/logging/LoggerFactory';
 
-const loggerFactory = new PinoLoggerFactory();
+const envService = container.get<EnvService>(ENV_SERVICE_ID);
+const loggerFactory = new PinoLoggerFactory(envService);
 const logger = loggerFactory.create('index');
 const bot = container.get<TelegramBot>(TelegramBot);
 

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -18,7 +18,7 @@ interface Migration {
 const envService = container.get<EnvService>(ENV_SERVICE_ID);
 const env = envService.env;
 const filename = parseDatabaseUrl(env.DATABASE_URL);
-const loggerFactory = new PinoLoggerFactory();
+const loggerFactory = new PinoLoggerFactory(envService);
 const logger = loggerFactory.create('migrate');
 
 function loadMigrations(dir = envService.getMigrationsDir()): Migration[] {


### PR DESCRIPTION
## Summary
- derive Pino log level from EnvService or process.env, defaulting to info
- inject EnvService into logger factory and pass level to child loggers
- wire up EnvService for standalone entry points

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage` *(fails: Coverage for branches (85.87%) does not meet global threshold (90%))*

------
https://chatgpt.com/codex/tasks/task_e_68a74466cff88327a48cca0c5678d343