### PR TITLE
chore(logging): ensure child loggers inherit level

### DIFF
--- a/src/services/logging/PinoLogger.ts
+++ b/src/services/logging/PinoLogger.ts
@@ -19,8 +19,10 @@ function resolveLogLevel(envService?: EnvService): LevelWithSilent {
  */
 export class PinoLogger implements Logger {
   private readonly logger: Pino;
+  private readonly envService?: EnvService;
 
   constructor(envService?: EnvService, logger?: Pino) {
+    this.envService = envService;
     const level = resolveLogLevel(envService);
     this.logger = logger ?? pino({ level });
     // Ensure provided loggers also respect the resolved level
@@ -69,6 +71,6 @@ export class PinoLogger implements Logger {
 
   child(meta: Record<string, unknown>): Logger {
     const childLogger = this.logger.child(meta);
-    return new PinoLogger(undefined, childLogger);
+    return new PinoLogger(this.envService, childLogger);
   }
 }

--- a/test/Logger.test.ts
+++ b/test/Logger.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { EnvService } from '../src/services/env/EnvService';
 
 describe('logger', () => {
   const OLD_ENV = { ...process.env };
@@ -30,5 +31,14 @@ describe('logger', () => {
     const child = logger.child({ service: 'test' });
     child.info('child');
     expect(typeof child.info).toBe('function');
+  });
+
+  it('child logger respects EnvService log level', async () => {
+    process.env.LOG_LEVEL = 'info';
+    const { PinoLogger } = await import('../src/services/logging/PinoLogger');
+    const envService = { env: { LOG_LEVEL: 'error' } } as unknown as EnvService;
+    const logger = new PinoLogger(envService);
+    const child = logger.child({ service: 'test' });
+    expect((child as any).logger.level).toBe('error');
   });
 });


### PR DESCRIPTION
## Summary
- retain EnvService on PinoLogger instances
- propagate EnvService to child loggers
- test child logger level inheritance

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage` *(fails: Coverage for branches (85.87%) < global threshold 90%)*

------
https://chatgpt.com/codex/tasks/task_e_68a748ec95448327855fab914fb7e712