### PR TITLE
Forbid default exports via ESLint

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -84,6 +84,7 @@ module.exports = [
           ],
         },
       ],
+      'import/no-default-export': 'error',
     },
     settings: {
       'import/extensions': ['.js', '.ts'],

--- a/src/bot/TelegramBot.ts
+++ b/src/bot/TelegramBot.ts
@@ -33,7 +33,7 @@ import {
   TriggerPipeline,
 } from '../services/chat/TriggerPipeline';
 import { Env, ENV_SERVICE_ID, EnvService } from '../services/env/EnvService';
-import type Logger from '../services/logging/Logger.interface';
+import type { Logger } from '../services/logging/Logger.interface';
 import {
   LOGGER_FACTORY_ID,
   type LoggerFactory,

--- a/src/repositories/DbProvider.ts
+++ b/src/repositories/DbProvider.ts
@@ -5,7 +5,7 @@ import { open } from 'sqlite';
 import sqlite3 from 'sqlite3';
 
 import { ENV_SERVICE_ID, EnvService } from '../services/env/EnvService';
-import type Logger from '../services/logging/Logger.interface';
+import type { Logger } from '../services/logging/Logger.interface';
 import {
   LOGGER_FACTORY_ID,
   type LoggerFactory,

--- a/src/services/admin/AdminServiceImpl.ts
+++ b/src/services/admin/AdminServiceImpl.ts
@@ -33,7 +33,7 @@ import {
   CHAT_CONFIG_SERVICE_ID,
   type ChatConfigService,
 } from '../chat/ChatConfigService';
-import type Logger from '../logging/Logger.interface';
+import type { Logger } from '../logging/Logger.interface';
 import {
   LOGGER_FACTORY_ID,
   type LoggerFactory,

--- a/src/services/ai/ChatGPTService.ts
+++ b/src/services/ai/ChatGPTService.ts
@@ -6,7 +6,7 @@ import path from 'path';
 
 import { TriggerReason } from '../../triggers/Trigger.interface';
 import { ENV_SERVICE_ID, EnvService } from '../env/EnvService';
-import type Logger from '../logging/Logger.interface';
+import type { Logger } from '../logging/Logger.interface';
 import {
   LOGGER_FACTORY_ID,
   type LoggerFactory,

--- a/src/services/chat/ChatApprovalService.ts
+++ b/src/services/chat/ChatApprovalService.ts
@@ -9,7 +9,7 @@ import {
   type ChatAccessRepository,
 } from '../../domain/repositories/ChatAccessRepository.interface';
 import { type Env, ENV_SERVICE_ID, type EnvService } from '../env/EnvService';
-import type Logger from '../logging/Logger.interface';
+import type { Logger } from '../logging/Logger.interface';
 import {
   LOGGER_FACTORY_ID,
   type LoggerFactory,

--- a/src/services/chat/ChatMemory.ts
+++ b/src/services/chat/ChatMemory.ts
@@ -1,7 +1,7 @@
 import { inject, injectable } from 'inversify';
 
 import { ChatMessage } from '../ai/AIService.interface';
-import type Logger from '../logging/Logger.interface';
+import type { Logger } from '../logging/Logger.interface';
 import {
   LOGGER_FACTORY_ID,
   type LoggerFactory,

--- a/src/services/chat/ChatResponder.ts
+++ b/src/services/chat/ChatResponder.ts
@@ -4,7 +4,7 @@ import { Context } from 'telegraf';
 
 import { TriggerReason } from '../../triggers/Trigger.interface';
 import { AI_SERVICE_ID, AIService } from '../ai/AIService.interface';
-import type Logger from '../logging/Logger.interface';
+import type { Logger } from '../logging/Logger.interface';
 import {
   LOGGER_FACTORY_ID,
   type LoggerFactory,

--- a/src/services/chat/DefaultChatResetService.ts
+++ b/src/services/chat/DefaultChatResetService.ts
@@ -1,6 +1,6 @@
 import { inject, injectable } from 'inversify';
 
-import type Logger from '../logging/Logger.interface';
+import type { Logger } from '../logging/Logger.interface';
 import {
   LOGGER_FACTORY_ID,
   type LoggerFactory,

--- a/src/services/chat/DialogueManager.ts
+++ b/src/services/chat/DialogueManager.ts
@@ -2,7 +2,7 @@ import type { ServiceIdentifier } from 'inversify';
 import { inject, injectable } from 'inversify';
 
 import { ENV_SERVICE_ID, type EnvService } from '../env/EnvService';
-import type Logger from '../logging/Logger.interface';
+import type { Logger } from '../logging/Logger.interface';
 import {
   LOGGER_FACTORY_ID,
   type LoggerFactory,

--- a/src/services/chat/HistorySummarizer.ts
+++ b/src/services/chat/HistorySummarizer.ts
@@ -10,7 +10,7 @@ import {
   AIService,
   ChatMessage,
 } from '../ai/AIService.interface';
-import type Logger from '../logging/Logger.interface';
+import type { Logger } from '../logging/Logger.interface';
 import {
   LOGGER_FACTORY_ID,
   type LoggerFactory,

--- a/src/services/chat/TriggerPipeline.ts
+++ b/src/services/chat/TriggerPipeline.ts
@@ -15,7 +15,7 @@ import {
   INTEREST_CHECKER_ID,
   InterestChecker,
 } from '../interest/InterestChecker';
-import type Logger from '../logging/Logger.interface';
+import type { Logger } from '../logging/Logger.interface';
 import {
   LOGGER_FACTORY_ID,
   type LoggerFactory,

--- a/src/services/interest/InterestChecker.ts
+++ b/src/services/interest/InterestChecker.ts
@@ -10,7 +10,7 @@ import {
   CHAT_CONFIG_SERVICE_ID,
   ChatConfigService,
 } from '../chat/ChatConfigService';
-import type Logger from '../logging/Logger.interface';
+import type { Logger } from '../logging/Logger.interface';
 import {
   LOGGER_FACTORY_ID,
   type LoggerFactory,

--- a/src/services/logging/Logger.interface.ts
+++ b/src/services/logging/Logger.interface.ts
@@ -1,4 +1,4 @@
-interface Logger {
+export interface Logger {
   debug(message: string): void;
   debug(meta: Record<string, unknown>, message: string): void;
 
@@ -13,5 +13,3 @@ interface Logger {
 
   child(meta: Record<string, unknown>): Logger;
 }
-
-export default Logger;

--- a/src/services/logging/LoggerFactory.ts
+++ b/src/services/logging/LoggerFactory.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from 'inversify';
 import pino, { type LevelWithSilent, type Logger as Pino } from 'pino';
 
 import { ENV_SERVICE_ID, type EnvService } from '../env/EnvService';
-import type Logger from './Logger.interface';
+import type { Logger } from './Logger.interface';
 import { PinoLogger } from './PinoLogger';
 
 export interface LoggerFactory {

--- a/src/services/logging/PinoLogger.ts
+++ b/src/services/logging/PinoLogger.ts
@@ -1,7 +1,7 @@
 import pino, { type LevelWithSilent, type Logger as Pino } from 'pino';
 
 import type { EnvService } from '../env/EnvService';
-import type Logger from './Logger.interface';
+import type { Logger } from './Logger.interface';
 
 function resolveLogLevel(envService?: EnvService): LevelWithSilent {
   return (

--- a/src/services/messages/InterestMessageStore.ts
+++ b/src/services/messages/InterestMessageStore.ts
@@ -1,7 +1,7 @@
 import { inject, injectable, type ServiceIdentifier } from 'inversify';
 
 import type { ChatMessage } from '../ai/AIService.interface';
-import type Logger from '../logging/Logger.interface';
+import type { Logger } from '../logging/Logger.interface';
 import {
   LOGGER_FACTORY_ID,
   type LoggerFactory,

--- a/src/services/messages/RepositoryMessageService.ts
+++ b/src/services/messages/RepositoryMessageService.ts
@@ -17,7 +17,7 @@ import {
   type UserRepository,
 } from '../../domain/repositories/UserRepository.interface';
 import type { ChatMessage } from '../ai/AIService.interface';
-import type Logger from '../logging/Logger.interface';
+import type { Logger } from '../logging/Logger.interface';
 import {
   LOGGER_FACTORY_ID,
   type LoggerFactory,

--- a/src/services/prompts/FilePromptService.ts
+++ b/src/services/prompts/FilePromptService.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from 'inversify';
 
 import { createLazy } from '../../utils/lazy';
 import { ENV_SERVICE_ID, EnvService } from '../env/EnvService';
-import type Logger from '../logging/Logger.interface';
+import type { Logger } from '../logging/Logger.interface';
 import {
   LOGGER_FACTORY_ID,
   type LoggerFactory,

--- a/src/services/summaries/RepositorySummaryService.ts
+++ b/src/services/summaries/RepositorySummaryService.ts
@@ -4,7 +4,7 @@ import {
   SUMMARY_REPOSITORY_ID,
   type SummaryRepository,
 } from '../../domain/repositories/SummaryRepository.interface';
-import type Logger from '../logging/Logger.interface';
+import type { Logger } from '../logging/Logger.interface';
 import {
   LOGGER_FACTORY_ID,
   type LoggerFactory,

--- a/src/triggers/InterestTrigger.ts
+++ b/src/triggers/InterestTrigger.ts
@@ -2,7 +2,7 @@ import type { Context } from 'telegraf';
 
 import type { DialogueManager } from '../services/chat/DialogueManager';
 import type { InterestChecker } from '../services/interest/InterestChecker';
-import type Logger from '../services/logging/Logger.interface';
+import type { Logger } from '../services/logging/Logger.interface';
 import { type LoggerFactory } from '../services/logging/LoggerFactory';
 import type {
   Trigger,

--- a/src/triggers/MentionTrigger.ts
+++ b/src/triggers/MentionTrigger.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'telegraf';
 
 import type { DialogueManager } from '../services/chat/DialogueManager';
-import type Logger from '../services/logging/Logger.interface';
+import type { Logger } from '../services/logging/Logger.interface';
 import { type LoggerFactory } from '../services/logging/LoggerFactory';
 import type {
   Trigger,

--- a/src/triggers/NameTrigger.ts
+++ b/src/triggers/NameTrigger.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'telegraf';
 
 import type { DialogueManager } from '../services/chat/DialogueManager';
-import type Logger from '../services/logging/Logger.interface';
+import type { Logger } from '../services/logging/Logger.interface';
 import { type LoggerFactory } from '../services/logging/LoggerFactory';
 import type {
   Trigger,

--- a/src/triggers/ReplyTrigger.ts
+++ b/src/triggers/ReplyTrigger.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'telegraf';
 
 import type { DialogueManager } from '../services/chat/DialogueManager';
-import type Logger from '../services/logging/Logger.interface';
+import type { Logger } from '../services/logging/Logger.interface';
 import { type LoggerFactory } from '../services/logging/LoggerFactory';
 import type {
   Trigger,


### PR DESCRIPTION
## Summary
- add ESLint rule to ban default exports
- switch Logger interface and imports to named exports

## Testing
- `npm run format:fix`
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:coverage` *(fails: Coverage for branches (85.9%) does not meet global threshold (90%))*

------
https://chatgpt.com/codex/tasks/task_e_68a74ed1208c83278e8a7d3ed81d12bb