### PR TITLE
refactor: extract service interfaces

### DIFF
--- a/src/application/interfaces/chat/ChatConfigService.errors.ts
+++ b/src/application/interfaces/chat/ChatConfigService.errors.ts
@@ -1,0 +1,2 @@
+export class InvalidHistoryLimitError extends Error {}
+export class InvalidInterestIntervalError extends Error {}

--- a/src/application/interfaces/chat/ChatConfigService.interface.ts
+++ b/src/application/interfaces/chat/ChatConfigService.interface.ts
@@ -8,9 +8,6 @@ export interface ChatConfigService {
   setInterestInterval(chatId: number, interestInterval: number): Promise<void>;
 }
 
-export class InvalidHistoryLimitError extends Error {}
-export class InvalidInterestIntervalError extends Error {}
-
 export const CHAT_CONFIG_SERVICE_ID = Symbol.for(
   'ChatConfigService'
 ) as ServiceIdentifier<ChatConfigService>;

--- a/src/application/interfaces/chat/ChatMemory.interface.ts
+++ b/src/application/interfaces/chat/ChatMemory.interface.ts
@@ -1,0 +1,7 @@
+import type { ChatMessage } from '../ai/AIService.interface';
+import type { StoredMessage } from '../messages/StoredMessage.interface';
+
+export interface ChatMemory {
+  addMessage(message: StoredMessage): Promise<void>;
+  getHistory(): Promise<ChatMessage[]>;
+}

--- a/src/application/interfaces/chat/ChatMemoryManager.interface.ts
+++ b/src/application/interfaces/chat/ChatMemoryManager.interface.ts
@@ -1,0 +1,12 @@
+import type { ServiceIdentifier } from 'inversify';
+
+import type { ChatMemory } from './ChatMemory.interface';
+
+export interface ChatMemoryManager {
+  get(chatId: number): Promise<ChatMemory>;
+  reset(chatId: number): Promise<void>;
+}
+
+export const CHAT_MEMORY_MANAGER_ID = Symbol.for(
+  'ChatMemoryManager'
+) as ServiceIdentifier<ChatMemoryManager>;

--- a/src/application/interfaces/env/EnvService.interface.ts
+++ b/src/application/interfaces/env/EnvService.interface.ts
@@ -1,18 +1,15 @@
 import type { ServiceIdentifier } from 'inversify';
 import type { ChatModel } from 'openai/resources/shared';
-import { z } from 'zod';
 
-export const envSchema = z.object({
-  BOT_TOKEN: z.string().min(1),
-  OPENAI_KEY: z.string().min(1),
-  DATABASE_URL: z.string().min(1),
-  LOG_LEVEL: z.string().default('debug'),
-  ADMIN_CHAT_ID: z.coerce.number(),
-  NODE_ENV: z.string().default('development'),
-  LOG_PROMPTS: z.coerce.boolean().default(false),
-});
-
-export type Env = z.infer<typeof envSchema>;
+export interface Env {
+  BOT_TOKEN: string;
+  OPENAI_KEY: string;
+  DATABASE_URL: string;
+  LOG_LEVEL: string;
+  ADMIN_CHAT_ID: number;
+  NODE_ENV: string;
+  LOG_PROMPTS: boolean;
+}
 
 export interface EnvService {
   readonly env: Env;

--- a/src/application/use-cases/chat/ChatMemory.ts
+++ b/src/application/use-cases/chat/ChatMemory.ts
@@ -5,6 +5,8 @@ import {
   CHAT_CONFIG_SERVICE_ID,
   type ChatConfigService,
 } from '../../interfaces/chat/ChatConfigService.interface';
+import type { ChatMemory as ChatMemoryInterface } from '../../interfaces/chat/ChatMemory.interface';
+import type { ChatMemoryManager as ChatMemoryManagerInterface } from '../../interfaces/chat/ChatMemoryManager.interface';
 import {
   CHAT_RESET_SERVICE_ID,
   type ChatResetService,
@@ -29,7 +31,7 @@ import {
 import { StoredMessage } from '../../interfaces/messages/StoredMessage.interface';
 
 @injectable()
-export class ChatMemory {
+export class ChatMemory implements ChatMemoryInterface {
   private readonly logger: Logger;
 
   constructor(
@@ -92,7 +94,7 @@ export class ChatMemory {
 }
 
 @injectable()
-export class ChatMemoryManager {
+export class ChatMemoryManager implements ChatMemoryManagerInterface {
   private readonly logger: Logger;
 
   constructor(

--- a/src/application/use-cases/chat/DefaultChatResponder.ts
+++ b/src/application/use-cases/chat/DefaultChatResponder.ts
@@ -6,6 +6,10 @@ import {
   AI_SERVICE_ID,
   AIService,
 } from '../../interfaces/ai/AIService.interface';
+import {
+  CHAT_MEMORY_MANAGER_ID,
+  ChatMemoryManager,
+} from '../../interfaces/chat/ChatMemoryManager.interface';
 import { type ChatResponder } from '../../interfaces/chat/ChatResponder.interface';
 import type { Logger } from '../../interfaces/logging/Logger.interface';
 import {
@@ -17,7 +21,6 @@ import {
   SummaryService,
 } from '../../interfaces/summaries/SummaryService.interface';
 import { MessageFactory } from '../messages/MessageFactory';
-import { ChatMemoryManager } from './ChatMemory';
 
 @injectable()
 export class DefaultChatResponder implements ChatResponder {
@@ -25,7 +28,7 @@ export class DefaultChatResponder implements ChatResponder {
 
   constructor(
     @inject(AI_SERVICE_ID) private ai: AIService,
-    @inject(ChatMemoryManager) private memories: ChatMemoryManager,
+    @inject(CHAT_MEMORY_MANAGER_ID) private memories: ChatMemoryManager,
     @inject(SUMMARY_SERVICE_ID) private summaries: SummaryService,
     @inject(LOGGER_FACTORY_ID) private loggerFactory: LoggerFactory
   ) {

--- a/src/application/use-cases/chat/RepositoryChatConfigService.ts
+++ b/src/application/use-cases/chat/RepositoryChatConfigService.ts
@@ -6,10 +6,10 @@ import {
   type ChatConfigRepository,
 } from '../../../domain/repositories/ChatConfigRepository.interface';
 import {
-  type ChatConfigService,
   InvalidHistoryLimitError,
   InvalidInterestIntervalError,
-} from '../../interfaces/chat/ChatConfigService.interface';
+} from '../../interfaces/chat/ChatConfigService.errors';
+import { type ChatConfigService } from '../../interfaces/chat/ChatConfigService.interface';
 
 const DEFAULT_HISTORY_LIMIT = 50;
 const DEFAULT_INTEREST_INTERVAL = 25;

--- a/src/application/use-cases/env/DefaultEnvService.ts
+++ b/src/application/use-cases/env/DefaultEnvService.ts
@@ -3,11 +3,8 @@ import 'dotenv/config';
 import { injectable } from 'inversify';
 import { ChatModel } from 'openai/resources/shared';
 
-import {
-  Env,
-  envSchema,
-  EnvService,
-} from '../../interfaces/env/EnvService.interface';
+import { Env, EnvService } from '../../interfaces/env/EnvService.interface';
+import { envSchema } from './envSchema';
 
 @injectable()
 export class DefaultEnvService implements EnvService {

--- a/src/application/use-cases/env/TestEnvService.ts
+++ b/src/application/use-cases/env/TestEnvService.ts
@@ -1,11 +1,8 @@
 import { injectable } from 'inversify';
 import { ChatModel } from 'openai/resources/shared';
 
-import {
-  Env,
-  envSchema,
-  EnvService,
-} from '../../interfaces/env/EnvService.interface';
+import { Env, EnvService } from '../../interfaces/env/EnvService.interface';
+import { envSchema } from './envSchema';
 
 @injectable()
 export class TestEnvService implements EnvService {

--- a/src/application/use-cases/env/envSchema.ts
+++ b/src/application/use-cases/env/envSchema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+import type { Env } from '../../interfaces/env/EnvService.interface';
+
+export const envSchema = z.object({
+  BOT_TOKEN: z.string().min(1),
+  OPENAI_KEY: z.string().min(1),
+  DATABASE_URL: z.string().min(1),
+  LOG_LEVEL: z.string().default('debug'),
+  ADMIN_CHAT_ID: z.coerce.number(),
+  NODE_ENV: z.string().default('development'),
+  LOG_PROMPTS: z.coerce.boolean().default(false),
+}) as z.ZodType<Env>;

--- a/src/bot/TelegramBot.ts
+++ b/src/bot/TelegramBot.ts
@@ -13,11 +13,17 @@ import {
   ChatApprovalService,
 } from '../application/interfaces/chat/ChatApprovalService.interface';
 import {
-  CHAT_CONFIG_SERVICE_ID,
-  ChatConfigService,
   InvalidHistoryLimitError,
   InvalidInterestIntervalError,
+} from '../application/interfaces/chat/ChatConfigService.errors';
+import {
+  CHAT_CONFIG_SERVICE_ID,
+  ChatConfigService,
 } from '../application/interfaces/chat/ChatConfigService.interface';
+import {
+  CHAT_MEMORY_MANAGER_ID,
+  ChatMemoryManager,
+} from '../application/interfaces/chat/ChatMemoryManager.interface';
 import {
   CHAT_RESPONDER_ID,
   ChatResponder,
@@ -40,7 +46,6 @@ import {
   MESSAGE_CONTEXT_EXTRACTOR_ID,
   MessageContextExtractor,
 } from '../application/interfaces/messages/MessageContextExtractor.interface';
-import { ChatMemoryManager } from '../application/use-cases/chat/ChatMemory';
 import { MessageFactory } from '../application/use-cases/messages/MessageFactory';
 import {
   CHAT_REPOSITORY_ID,
@@ -83,7 +88,7 @@ export class TelegramBot {
 
   constructor(
     @inject(ENV_SERVICE_ID) envService: EnvService,
-    @inject(ChatMemoryManager) private memories: ChatMemoryManager,
+    @inject(CHAT_MEMORY_MANAGER_ID) private memories: ChatMemoryManager,
     @inject(ADMIN_SERVICE_ID) private admin: AdminService,
     @inject(CHAT_APPROVAL_SERVICE_ID)
     private approvalService: ChatApprovalService,

--- a/src/container.ts
+++ b/src/container.ts
@@ -9,6 +9,7 @@ import {
   CHAT_CONFIG_SERVICE_ID,
   type ChatConfigService,
 } from './application/interfaces/chat/ChatConfigService.interface';
+import { CHAT_MEMORY_MANAGER_ID } from './application/interfaces/chat/ChatMemoryManager.interface';
 import { CHAT_RESET_SERVICE_ID } from './application/interfaces/chat/ChatResetService.interface';
 import {
   CHAT_RESPONDER_ID,
@@ -157,7 +158,7 @@ container
   .to(SQLiteChatConfigRepository)
   .inSingletonScope();
 
-container.bind(ChatMemoryManager).toSelf().inSingletonScope();
+container.bind(CHAT_MEMORY_MANAGER_ID).to(ChatMemoryManager).inSingletonScope();
 
 container
   .bind(DIALOGUE_MANAGER_ID)

--- a/test/ChatResponder.test.ts
+++ b/test/ChatResponder.test.ts
@@ -5,7 +5,7 @@ import type {
   AIService,
   ChatMessage,
 } from '../src/application/interfaces/ai/AIService.interface';
-import type { ChatMemoryManager } from '../src/application/use-cases/chat/ChatMemory';
+import type { ChatMemoryManager } from '../src/application/interfaces/chat/ChatMemoryManager.interface';
 import { ChatResponder } from '../src/application/interfaces/chat/ChatResponder.interface';
 import { DefaultChatResponder } from '../src/application/use-cases/chat/DefaultChatResponder';
 import type { SummaryService } from '../src/application/interfaces/summaries/SummaryService.interface';

--- a/test/TelegramBot.test.ts
+++ b/test/TelegramBot.test.ts
@@ -8,7 +8,7 @@ import { createWindows } from '../src/bot/windowConfig';
 import type { ChatRepository } from '../src/domain/repositories/ChatRepository.interface';
 import type { AdminService } from '../src/application/interfaces/admin/AdminService.interface';
 import type { ChatApprovalService } from '../src/application/interfaces/chat/ChatApprovalService.interface';
-import type { ChatMemoryManager } from '../src/application/use-cases/chat/ChatMemory';
+import type { ChatMemoryManager } from '../src/application/interfaces/chat/ChatMemoryManager.interface';
 import type { ChatResponder } from '../src/application/interfaces/chat/ChatResponder.interface';
 import type { TriggerPipeline } from '../src/application/interfaces/chat/TriggerPipeline.interface';
 import type { EnvService } from '../src/application/interfaces/env/EnvService.interface';
@@ -16,7 +16,7 @@ import type { ChatConfigService } from '../src/application/interfaces/chat/ChatC
 import {
   InvalidInterestIntervalError,
   InvalidHistoryLimitError,
-} from '../src/application/interfaces/chat/ChatConfigService.interface';
+} from '../src/application/interfaces/chat/ChatConfigService.errors';
 import type {
   MessageContext,
   MessageContextExtractor,


### PR DESCRIPTION
## Summary
- define ChatMemory and ChatMemoryManager interfaces with DI keys
- move ChatConfig errors into separate file and clean interfaces
- relocate environment schema from EnvService interface to dedicated module

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a7b093bc788327b343a1836499c2ea