### PR TITLE
Inject trigger dependencies via interfaces

### DIFF
--- a/src/application/use-cases/chat/DefaultTriggerPipeline.ts
+++ b/src/application/use-cases/chat/DefaultTriggerPipeline.ts
@@ -1,11 +1,12 @@
 import { inject, injectable } from 'inversify';
 import { Context } from 'telegraf';
 
-import { InterestTrigger } from '../../../triggers/InterestTrigger';
-import { MentionTrigger } from '../../../triggers/MentionTrigger';
-import { NameTrigger } from '../../../triggers/NameTrigger';
-import { ReplyTrigger } from '../../../triggers/ReplyTrigger';
 import {
+  INTEREST_TRIGGER_ID,
+  MENTION_TRIGGER_ID,
+  NAME_TRIGGER_ID,
+  REPLY_TRIGGER_ID,
+  Trigger,
   TriggerContext,
   TriggerResult,
 } from '../../../triggers/Trigger.interface';
@@ -14,14 +15,6 @@ import {
   type DialogueManager,
 } from '../../interfaces/chat/DialogueManager.interface';
 import { type TriggerPipeline } from '../../interfaces/chat/TriggerPipeline.interface';
-import {
-  ENV_SERVICE_ID,
-  EnvService,
-} from '../../interfaces/env/EnvService.interface';
-import {
-  INTEREST_CHECKER_ID,
-  InterestChecker,
-} from '../../interfaces/interest/InterestChecker.interface';
 import type { Logger } from '../../interfaces/logging/Logger.interface';
 import {
   LOGGER_FACTORY_ID,
@@ -30,23 +23,25 @@ import {
 
 @injectable()
 export class DefaultTriggerPipeline implements TriggerPipeline {
-  private mentionTrigger: MentionTrigger;
-  private replyTrigger: ReplyTrigger;
-  private nameTrigger: NameTrigger;
-  private interestTrigger: InterestTrigger;
+  private mentionTrigger: Trigger;
+  private replyTrigger: Trigger;
+  private nameTrigger: Trigger;
+  private interestTrigger: Trigger;
   private readonly logger: Logger;
 
   constructor(
-    @inject(ENV_SERVICE_ID) envService: EnvService,
-    @inject(INTEREST_CHECKER_ID) interestChecker: InterestChecker,
     @inject(DIALOGUE_MANAGER_ID) private dialogue: DialogueManager,
+    @inject(MENTION_TRIGGER_ID) mentionTrigger: Trigger,
+    @inject(REPLY_TRIGGER_ID) replyTrigger: Trigger,
+    @inject(NAME_TRIGGER_ID) nameTrigger: Trigger,
+    @inject(INTEREST_TRIGGER_ID) interestTrigger: Trigger,
     @inject(LOGGER_FACTORY_ID) loggerFactory: LoggerFactory
   ) {
     this.logger = loggerFactory.create('DefaultTriggerPipeline');
-    this.nameTrigger = new NameTrigger(envService.getBotName(), loggerFactory);
-    this.interestTrigger = new InterestTrigger(interestChecker, loggerFactory);
-    this.mentionTrigger = new MentionTrigger(loggerFactory);
-    this.replyTrigger = new ReplyTrigger(loggerFactory);
+    this.nameTrigger = nameTrigger;
+    this.interestTrigger = interestTrigger;
+    this.mentionTrigger = mentionTrigger;
+    this.replyTrigger = replyTrigger;
   }
 
   async shouldRespond(

--- a/src/container.ts
+++ b/src/container.ts
@@ -75,6 +75,16 @@ import { SQLiteChatUserRepository } from './repositories/sqlite/SQLiteChatUserRe
 import { SQLiteMessageRepository } from './repositories/sqlite/SQLiteMessageRepository';
 import { SQLiteSummaryRepository } from './repositories/sqlite/SQLiteSummaryRepository';
 import { SQLiteUserRepository } from './repositories/sqlite/SQLiteUserRepository';
+import { InterestTrigger } from './triggers/InterestTrigger';
+import { MentionTrigger } from './triggers/MentionTrigger';
+import { NameTrigger } from './triggers/NameTrigger';
+import { ReplyTrigger } from './triggers/ReplyTrigger';
+import {
+  INTEREST_TRIGGER_ID,
+  MENTION_TRIGGER_ID,
+  NAME_TRIGGER_ID,
+  REPLY_TRIGGER_ID,
+} from './triggers/Trigger.interface';
 
 export const container = new Container();
 
@@ -125,6 +135,44 @@ container
 container
   .bind(INTEREST_CHECKER_ID)
   .to(DefaultInterestChecker)
+  .inSingletonScope();
+
+container
+  .bind(INTEREST_TRIGGER_ID)
+  .toDynamicValue((ctx) => {
+    const c = (ctx as unknown as { container: Container }).container;
+    return new InterestTrigger(
+      c.get(INTEREST_CHECKER_ID),
+      c.get(LOGGER_FACTORY_ID)
+    );
+  })
+  .inSingletonScope();
+
+container
+  .bind(MENTION_TRIGGER_ID)
+  .toDynamicValue((ctx) => {
+    const c = (ctx as unknown as { container: Container }).container;
+    return new MentionTrigger(c.get(LOGGER_FACTORY_ID));
+  })
+  .inSingletonScope();
+
+container
+  .bind(REPLY_TRIGGER_ID)
+  .toDynamicValue((ctx) => {
+    const c = (ctx as unknown as { container: Container }).container;
+    return new ReplyTrigger(c.get(LOGGER_FACTORY_ID));
+  })
+  .inSingletonScope();
+
+container
+  .bind(NAME_TRIGGER_ID)
+  .toDynamicValue((ctx) => {
+    const c = (ctx as unknown as { container: Container }).container;
+    return new NameTrigger(
+      c.get<EnvService>(ENV_SERVICE_ID).getBotName(),
+      c.get(LOGGER_FACTORY_ID)
+    );
+  })
   .inSingletonScope();
 
 container.bind(ADMIN_SERVICE_ID).to(AdminServiceImpl).inSingletonScope();

--- a/src/triggers/Trigger.interface.ts
+++ b/src/triggers/Trigger.interface.ts
@@ -1,3 +1,4 @@
+import type { ServiceIdentifier } from 'inversify';
 import type { Context } from 'telegraf';
 
 import type { DialogueManager } from '../application/interfaces/chat/DialogueManager.interface';
@@ -25,3 +26,16 @@ export interface Trigger {
     dialogue: DialogueManager
   ): Promise<TriggerResult | null>;
 }
+
+export const MENTION_TRIGGER_ID = Symbol.for(
+  'MentionTrigger'
+) as ServiceIdentifier<Trigger>;
+export const REPLY_TRIGGER_ID = Symbol.for(
+  'ReplyTrigger'
+) as ServiceIdentifier<Trigger>;
+export const NAME_TRIGGER_ID = Symbol.for(
+  'NameTrigger'
+) as ServiceIdentifier<Trigger>;
+export const INTEREST_TRIGGER_ID = Symbol.for(
+  'InterestTrigger'
+) as ServiceIdentifier<Trigger>;


### PR DESCRIPTION
## Summary
- inject trigger implementations into DefaultTriggerPipeline instead of instantiating directly
- expose trigger service identifiers and bind concrete implementations in container
- adjust TriggerPipeline tests for new injected dependencies

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a7b66e24608327b949c909597bf5fa