### PR TITLE
refactor: decouple admin service from infrastructure db provider

### DIFF
--- a/src/application/use-cases/admin/AdminServiceImpl.ts
+++ b/src/application/use-cases/admin/AdminServiceImpl.ts
@@ -1,7 +1,6 @@
 import { randomBytes } from 'node:crypto';
 
 import { inject, injectable } from 'inversify';
-import type { Database } from 'sqlite';
 
 import type { UserEntity } from '../../../domain/entities/UserEntity';
 import {
@@ -12,6 +11,11 @@ import {
   CHAT_USER_REPOSITORY_ID,
   type ChatUserRepository,
 } from '../../../domain/repositories/ChatUserRepository.interface';
+import {
+  DB_PROVIDER_ID,
+  type DbProvider,
+  type SqlDatabase,
+} from '../../../domain/repositories/DbProvider.interface';
 import {
   MESSAGE_REPOSITORY_ID,
   type MessageRepository,
@@ -24,10 +28,6 @@ import {
   USER_REPOSITORY_ID,
   type UserRepository,
 } from '../../../domain/repositories/UserRepository.interface';
-import {
-  DB_PROVIDER_ID,
-  type SQLiteDbProvider,
-} from '../../../infrastructure/repositories/DbProvider';
 import { AdminService } from '../../interfaces/admin/AdminService.interface';
 import type { ChatMessage } from '../../interfaces/ai/AIService.interface';
 import {
@@ -45,7 +45,7 @@ export class AdminServiceImpl implements AdminService {
   private readonly logger: Logger;
 
   constructor(
-    @inject(DB_PROVIDER_ID) private dbProvider: SQLiteDbProvider,
+    @inject(DB_PROVIDER_ID) private dbProvider: DbProvider,
     @inject(ACCESS_KEY_REPOSITORY_ID)
     private accessKeyRepo: AccessKeyRepository,
     @inject(MESSAGE_REPOSITORY_ID) private messageRepo: MessageRepository,
@@ -168,7 +168,7 @@ export class AdminServiceImpl implements AdminService {
   }
 
   private async exportTable(
-    db: Database,
+    db: SqlDatabase,
     table: string
   ): Promise<Buffer | null> {
     try {

--- a/src/container.ts
+++ b/src/container.ts
@@ -114,6 +114,10 @@ import {
   type ChatUserRepository,
 } from './domain/repositories/ChatUserRepository.interface';
 import {
+  DB_PROVIDER_ID,
+  type DbProvider,
+} from './domain/repositories/DbProvider.interface';
+import {
   MESSAGE_REPOSITORY_ID,
   type MessageRepository,
 } from './domain/repositories/MessageRepository.interface';
@@ -126,11 +130,7 @@ import {
   type UserRepository,
 } from './domain/repositories/UserRepository.interface';
 import { PinoLoggerFactory } from './infrastructure/logging/PinoLoggerFactory';
-import {
-  DB_PROVIDER_ID,
-  type DbProvider,
-  SQLiteDbProviderImpl,
-} from './infrastructure/repositories/DbProvider';
+import { SQLiteDbProviderImpl } from './infrastructure/repositories/DbProvider';
 import { SQLiteAccessKeyRepository } from './infrastructure/repositories/SQLiteAccessKeyRepository';
 import { SQLiteChatAccessRepository } from './infrastructure/repositories/SQLiteChatAccessRepository';
 import { SQLiteChatConfigRepository } from './infrastructure/repositories/SQLiteChatConfigRepository';

--- a/src/domain/repositories/DbProvider.interface.ts
+++ b/src/domain/repositories/DbProvider.interface.ts
@@ -1,0 +1,16 @@
+import type { ServiceIdentifier } from 'inversify';
+
+export interface SqlDatabase {
+  run(sql: string, ...params: unknown[]): Promise<unknown>;
+  get<T>(sql: string, ...params: unknown[]): Promise<T | undefined>;
+  all<T>(sql: string, ...params: unknown[]): Promise<T[]>;
+}
+
+export interface DbProvider {
+  get(): Promise<SqlDatabase>;
+  listTables(): Promise<string[]>;
+}
+
+export const DB_PROVIDER_ID = Symbol.for(
+  'DbProvider'
+) as ServiceIdentifier<DbProvider>;

--- a/src/infrastructure/repositories/SQLiteAccessKeyRepository.ts
+++ b/src/infrastructure/repositories/SQLiteAccessKeyRepository.ts
@@ -1,13 +1,16 @@
 import { inject, injectable } from 'inversify';
-import type { Database } from 'sqlite';
 
 import type { AccessKeyEntity } from '../../domain/entities/AccessKeyEntity';
 import type { AccessKeyRepository } from '../../domain/repositories/AccessKeyRepository.interface';
-import { DB_PROVIDER_ID, type SQLiteDbProvider } from './DbProvider';
+import {
+  DB_PROVIDER_ID,
+  type DbProvider,
+  type SqlDatabase,
+} from '../../domain/repositories/DbProvider.interface';
 
 @injectable()
 export class SQLiteAccessKeyRepository implements AccessKeyRepository {
-  constructor(@inject(DB_PROVIDER_ID) private dbProvider: SQLiteDbProvider) {}
+  constructor(@inject(DB_PROVIDER_ID) private dbProvider: DbProvider) {}
   async upsertKey({
     chatId,
     userId,
@@ -54,7 +57,7 @@ export class SQLiteAccessKeyRepository implements AccessKeyRepository {
     await db.run('DELETE FROM access_keys WHERE expires_at <= ?', now);
   }
 
-  private async db(): Promise<Database> {
+  private async db(): Promise<SqlDatabase> {
     return this.dbProvider.get();
   }
 }

--- a/src/infrastructure/repositories/SQLiteChatConfigRepository.ts
+++ b/src/infrastructure/repositories/SQLiteChatConfigRepository.ts
@@ -1,13 +1,16 @@
 import { inject, injectable } from 'inversify';
-import type { Database } from 'sqlite';
 
 import type { ChatConfigEntity } from '../../domain/entities/ChatConfigEntity';
 import type { ChatConfigRepository } from '../../domain/repositories/ChatConfigRepository.interface';
-import { DB_PROVIDER_ID, type SQLiteDbProvider } from './DbProvider';
+import {
+  DB_PROVIDER_ID,
+  type DbProvider,
+  type SqlDatabase,
+} from '../../domain/repositories/DbProvider.interface';
 
 @injectable()
 export class SQLiteChatConfigRepository implements ChatConfigRepository {
-  constructor(@inject(DB_PROVIDER_ID) private dbProvider: SQLiteDbProvider) {}
+  constructor(@inject(DB_PROVIDER_ID) private dbProvider: DbProvider) {}
 
   async upsert({
     chatId,
@@ -42,7 +45,7 @@ export class SQLiteChatConfigRepository implements ChatConfigRepository {
       : undefined;
   }
 
-  private async db(): Promise<Database> {
+  private async db(): Promise<SqlDatabase> {
     return this.dbProvider.get();
   }
 }

--- a/src/infrastructure/repositories/SQLiteChatRepository.ts
+++ b/src/infrastructure/repositories/SQLiteChatRepository.ts
@@ -1,13 +1,16 @@
 import { inject, injectable } from 'inversify';
-import type { Database } from 'sqlite';
 
 import type { ChatEntity } from '../../domain/entities/ChatEntity';
 import type { ChatRepository } from '../../domain/repositories/ChatRepository.interface';
-import { DB_PROVIDER_ID, type SQLiteDbProvider } from './DbProvider';
+import {
+  DB_PROVIDER_ID,
+  type DbProvider,
+  type SqlDatabase,
+} from '../../domain/repositories/DbProvider.interface';
 
 @injectable()
 export class SQLiteChatRepository implements ChatRepository {
-  constructor(@inject(DB_PROVIDER_ID) private dbProvider: SQLiteDbProvider) {}
+  constructor(@inject(DB_PROVIDER_ID) private dbProvider: DbProvider) {}
   async upsert({ chatId, title }: ChatEntity): Promise<void> {
     const db = await this.db();
     await db.run(
@@ -26,7 +29,7 @@ export class SQLiteChatRepository implements ChatRepository {
     return row ? { chatId: row.chat_id, title: row.title } : undefined;
   }
 
-  private async db(): Promise<Database> {
+  private async db(): Promise<SqlDatabase> {
     return this.dbProvider.get();
   }
 }

--- a/src/infrastructure/repositories/SQLiteChatUserRepository.ts
+++ b/src/infrastructure/repositories/SQLiteChatUserRepository.ts
@@ -1,12 +1,15 @@
 import { inject, injectable } from 'inversify';
-import type { Database } from 'sqlite';
 
 import type { ChatUserRepository } from '../../domain/repositories/ChatUserRepository.interface';
-import { DB_PROVIDER_ID, type SQLiteDbProvider } from './DbProvider';
+import {
+  DB_PROVIDER_ID,
+  type DbProvider,
+  type SqlDatabase,
+} from '../../domain/repositories/DbProvider.interface';
 
 @injectable()
 export class SQLiteChatUserRepository implements ChatUserRepository {
-  constructor(@inject(DB_PROVIDER_ID) private dbProvider: SQLiteDbProvider) {}
+  constructor(@inject(DB_PROVIDER_ID) private dbProvider: DbProvider) {}
   async link(chatId: number, userId: number): Promise<void> {
     const db = await this.db();
     await db.run(
@@ -18,15 +21,13 @@ export class SQLiteChatUserRepository implements ChatUserRepository {
 
   async listByChat(chatId: number): Promise<number[]> {
     const db = await this.db();
-    const rows = await db.all<
-      {
-        user_id: number;
-      }[]
-    >('SELECT user_id FROM chat_users WHERE chat_id = ?', chatId);
+    const rows = await db.all<{
+      user_id: number;
+    }>('SELECT user_id FROM chat_users WHERE chat_id = ?', chatId);
     return (rows ?? []).map((row) => row.user_id);
   }
 
-  private async db(): Promise<Database> {
+  private async db(): Promise<SqlDatabase> {
     return this.dbProvider.get();
   }
 }

--- a/src/infrastructure/repositories/SQLiteMessageRepository.ts
+++ b/src/infrastructure/repositories/SQLiteMessageRepository.ts
@@ -1,14 +1,17 @@
 import { inject, injectable } from 'inversify';
-import type { Database } from 'sqlite';
 
 import type { ChatMessage } from '../../application/interfaces/ai/AIService.interface';
 import type { StoredMessage } from '../../application/interfaces/messages/StoredMessage.interface';
+import {
+  DB_PROVIDER_ID,
+  type DbProvider,
+  type SqlDatabase,
+} from '../../domain/repositories/DbProvider.interface';
 import type { MessageRepository } from '../../domain/repositories/MessageRepository.interface';
-import { DB_PROVIDER_ID, type SQLiteDbProvider } from './DbProvider';
 
 @injectable()
 export class SQLiteMessageRepository implements MessageRepository {
-  constructor(@inject(DB_PROVIDER_ID) private dbProvider: SQLiteDbProvider) {}
+  constructor(@inject(DB_PROVIDER_ID) private dbProvider: DbProvider) {}
   async insert({
     chatId,
     messageId,
@@ -35,22 +38,20 @@ export class SQLiteMessageRepository implements MessageRepository {
 
   async findByChatId(chatId: number): Promise<ChatMessage[]> {
     const db = await this.db();
-    const rows = await db.all<
-      {
-        role: 'user' | 'assistant';
-        content: string;
-        username: string | null;
-        first_name: string | null;
-        last_name: string | null;
-        reply_text: string | null;
-        reply_username: string | null;
-        quote_text: string | null;
-        user_id: number | null;
-        chat_id: number | null;
-        message_id: number | null;
-        attitude: string | null;
-      }[]
-    >(
+    const rows = await db.all<{
+      role: 'user' | 'assistant';
+      content: string;
+      username: string | null;
+      first_name: string | null;
+      last_name: string | null;
+      reply_text: string | null;
+      reply_username: string | null;
+      quote_text: string | null;
+      user_id: number | null;
+      chat_id: number | null;
+      message_id: number | null;
+      attitude: string | null;
+    }>(
       'SELECT m.role, m.content, u.username, u.first_name, u.last_name, u.attitude, m.reply_text, m.reply_username, m.quote_text, m.user_id, c.chat_id, m.message_id FROM messages m LEFT JOIN users u ON m.user_id = u.id LEFT JOIN chats c ON m.chat_id = c.chat_id WHERE m.chat_id = ? ORDER BY m.id',
       chatId
     );
@@ -89,22 +90,20 @@ export class SQLiteMessageRepository implements MessageRepository {
     limit: number
   ): Promise<ChatMessage[]> {
     const db = await this.db();
-    const rows = await db.all<
-      {
-        role: 'user' | 'assistant';
-        content: string;
-        username: string | null;
-        first_name: string | null;
-        last_name: string | null;
-        reply_text: string | null;
-        reply_username: string | null;
-        quote_text: string | null;
-        user_id: number | null;
-        chat_id: number | null;
-        message_id: number | null;
-        attitude: string | null;
-      }[]
-    >(
+    const rows = await db.all<{
+      role: 'user' | 'assistant';
+      content: string;
+      username: string | null;
+      first_name: string | null;
+      last_name: string | null;
+      reply_text: string | null;
+      reply_username: string | null;
+      quote_text: string | null;
+      user_id: number | null;
+      chat_id: number | null;
+      message_id: number | null;
+      attitude: string | null;
+    }>(
       'SELECT m.role, m.content, u.username, u.first_name, u.last_name, u.attitude, m.reply_text, m.reply_username, m.quote_text, m.user_id, c.chat_id, m.message_id FROM messages m LEFT JOIN users u ON m.user_id = u.id LEFT JOIN chats c ON m.chat_id = c.chat_id WHERE m.chat_id = ? ORDER BY m.id DESC LIMIT ?',
       chatId,
       limit
@@ -135,7 +134,7 @@ export class SQLiteMessageRepository implements MessageRepository {
     await db.run('DELETE FROM messages WHERE chat_id = ?', chatId);
   }
 
-  private async db(): Promise<Database> {
+  private async db(): Promise<SqlDatabase> {
     return this.dbProvider.get();
   }
 }

--- a/src/infrastructure/repositories/SQLiteSummaryRepository.ts
+++ b/src/infrastructure/repositories/SQLiteSummaryRepository.ts
@@ -1,12 +1,15 @@
 import { inject, injectable } from 'inversify';
-import type { Database } from 'sqlite';
 
+import {
+  DB_PROVIDER_ID,
+  type DbProvider,
+  type SqlDatabase,
+} from '../../domain/repositories/DbProvider.interface';
 import type { SummaryRepository } from '../../domain/repositories/SummaryRepository.interface';
-import { DB_PROVIDER_ID, type SQLiteDbProvider } from './DbProvider';
 
 @injectable()
 export class SQLiteSummaryRepository implements SummaryRepository {
-  constructor(@inject(DB_PROVIDER_ID) private dbProvider: SQLiteDbProvider) {}
+  constructor(@inject(DB_PROVIDER_ID) private dbProvider: DbProvider) {}
   async upsert(chatId: number, summary: string): Promise<void> {
     const db = await this.db();
     await db.run(
@@ -30,7 +33,7 @@ export class SQLiteSummaryRepository implements SummaryRepository {
     await db.run('DELETE FROM summaries WHERE chat_id = ?', chatId);
   }
 
-  private async db(): Promise<Database> {
+  private async db(): Promise<SqlDatabase> {
     return this.dbProvider.get();
   }
 }

--- a/src/infrastructure/repositories/SQLiteUserRepository.ts
+++ b/src/infrastructure/repositories/SQLiteUserRepository.ts
@@ -1,13 +1,16 @@
 import { inject, injectable } from 'inversify';
-import type { Database } from 'sqlite';
 
 import type { UserEntity } from '../../domain/entities/UserEntity';
+import {
+  DB_PROVIDER_ID,
+  type DbProvider,
+  type SqlDatabase,
+} from '../../domain/repositories/DbProvider.interface';
 import type { UserRepository } from '../../domain/repositories/UserRepository.interface';
-import { DB_PROVIDER_ID, type SQLiteDbProvider } from './DbProvider';
 
 @injectable()
 export class SQLiteUserRepository implements UserRepository {
-  constructor(@inject(DB_PROVIDER_ID) private dbProvider: SQLiteDbProvider) {}
+  constructor(@inject(DB_PROVIDER_ID) private dbProvider: DbProvider) {}
   async upsert({
     id,
     username,
@@ -58,7 +61,7 @@ export class SQLiteUserRepository implements UserRepository {
     );
   }
 
-  private async db(): Promise<Database> {
+  private async db(): Promise<SqlDatabase> {
     return this.dbProvider.get();
   }
 }

--- a/test/AdminServiceImpl.test.ts
+++ b/test/AdminServiceImpl.test.ts
@@ -1,7 +1,9 @@
-import type { Database } from 'sqlite';
 import { describe, expect, it, vi } from 'vitest';
 
-import type { DbProvider } from '../src/infrastructure/repositories/DbProvider';
+import type {
+  DbProvider,
+  SqlDatabase,
+} from '../src/domain/repositories/DbProvider.interface';
 import type { AccessKeyRepository } from '../src/domain/repositories/AccessKeyRepository.interface';
 import type { ChatUserRepository } from '../src/domain/repositories/ChatUserRepository.interface';
 import type { MessageRepository } from '../src/domain/repositories/MessageRepository.interface';
@@ -36,7 +38,7 @@ describe('AdminServiceImpl', () => {
       findByChatAndUser: vi.fn(),
     } as unknown as AccessKeyRepository;
     const admin = new AdminServiceImpl(
-      { get: vi.fn(), listTables: vi.fn() } as unknown as DbProvider<Database>,
+      { get: vi.fn(), listTables: vi.fn() } as unknown as DbProvider,
       accessRepo,
       {} as unknown as MessageRepository,
       {} as unknown as SummaryRepository,
@@ -61,7 +63,7 @@ describe('AdminServiceImpl', () => {
       findByChatAndUser: vi.fn(async () => ({ chatId: 1, userId: 2 })),
     } as unknown as AccessKeyRepository;
     const admin = new AdminServiceImpl(
-      { get: vi.fn(), listTables: vi.fn() } as unknown as DbProvider<Database>,
+      { get: vi.fn(), listTables: vi.fn() } as unknown as DbProvider,
       accessRepo,
       {} as unknown as MessageRepository,
       {} as unknown as SummaryRepository,
@@ -81,11 +83,11 @@ describe('AdminServiceImpl', () => {
       .fn()
       .mockResolvedValueOnce([{ id: 1 }])
       .mockResolvedValueOnce([]);
-    const db = { all: dbAll } as unknown as Database;
+    const db = { all: dbAll } as unknown as SqlDatabase;
     const provider = {
       get: vi.fn(async () => db),
       listTables: vi.fn(async () => ['t']),
-    } as unknown as DbProvider<Database>;
+    } as unknown as DbProvider;
     const admin = new AdminServiceImpl(
       provider,
       {} as unknown as AccessKeyRepository,
@@ -131,8 +133,8 @@ describe('AdminServiceImpl', () => {
       })),
     };
     const admin = new AdminServiceImpl(
-      { get: vi.fn(), listTables: vi.fn() } as unknown as DbProvider<Database>,
-      {} as unknown as Database,
+      { get: vi.fn(), listTables: vi.fn() } as unknown as DbProvider,
+      {} as unknown as AccessKeyRepository,
       messageRepo as unknown as MessageRepository,
       summaryRepo as unknown as SummaryRepository,
       chatUserRepo as unknown as ChatUserRepository,


### PR DESCRIPTION
## Summary
- define DbProvider interface in domain to abstract database access
- inject DbProvider into AdminService and SQLite repositories
- update container bindings and SQLite implementation

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a7ccb83bbc8327b64910445c785827