### PR TITLE
Move Trigger interface to domain layer

### DIFF
--- a/src/application/interfaces/ai/AIService.interface.ts
+++ b/src/application/interfaces/ai/AIService.interface.ts
@@ -12,7 +12,7 @@ export interface ChatMessage {
   attitude?: string | null;
 }
 
-import type { TriggerReason } from '../../../triggers/Trigger.interface';
+import type { TriggerReason } from '../../../domain/triggers/Trigger.interface';
 
 export interface AIService {
   ask(

--- a/src/application/interfaces/chat/ChatResponder.interface.ts
+++ b/src/application/interfaces/chat/ChatResponder.interface.ts
@@ -1,7 +1,7 @@
 import type { ServiceIdentifier } from 'inversify';
 import type { Context } from 'telegraf';
 
-import type { TriggerReason } from '../../../triggers/Trigger.interface';
+import type { TriggerReason } from '../../../domain/triggers/Trigger.interface';
 
 export interface ChatResponder {
   generate(

--- a/src/application/interfaces/chat/TriggerPipeline.interface.ts
+++ b/src/application/interfaces/chat/TriggerPipeline.interface.ts
@@ -4,7 +4,7 @@ import type { Context } from 'telegraf';
 import type {
   TriggerContext,
   TriggerResult,
-} from '../../../triggers/Trigger.interface';
+} from '../../../domain/triggers/Trigger.interface';
 
 export interface TriggerPipeline {
   shouldRespond(

--- a/src/application/use-cases/ai/ChatGPTService.ts
+++ b/src/application/use-cases/ai/ChatGPTService.ts
@@ -4,7 +4,7 @@ import OpenAI from 'openai';
 import { ChatModel } from 'openai/resources/shared';
 import path from 'path';
 
-import { TriggerReason } from '../../../triggers/Trigger.interface';
+import { TriggerReason } from '../../../domain/triggers/Trigger.interface';
 import {
   AIService,
   ChatMessage,

--- a/src/application/use-cases/chat/DefaultChatResponder.ts
+++ b/src/application/use-cases/chat/DefaultChatResponder.ts
@@ -1,7 +1,7 @@
 import { inject, injectable } from 'inversify';
 import { Context } from 'telegraf';
 
-import { TriggerReason } from '../../../triggers/Trigger.interface';
+import { TriggerReason } from '../../../domain/triggers/Trigger.interface';
 import {
   AI_SERVICE_ID,
   AIService,

--- a/src/application/use-cases/chat/DefaultTriggerPipeline.ts
+++ b/src/application/use-cases/chat/DefaultTriggerPipeline.ts
@@ -1,14 +1,14 @@
 import { inject, injectable } from 'inversify';
 import { Context } from 'telegraf';
 
+import {
+  TriggerContext,
+  TriggerResult,
+} from '../../../domain/triggers/Trigger.interface';
 import { InterestTrigger } from '../../../triggers/InterestTrigger';
 import { MentionTrigger } from '../../../triggers/MentionTrigger';
 import { NameTrigger } from '../../../triggers/NameTrigger';
 import { ReplyTrigger } from '../../../triggers/ReplyTrigger';
-import {
-  TriggerContext,
-  TriggerResult,
-} from '../../../triggers/Trigger.interface';
 import {
   DIALOGUE_MANAGER_ID,
   type DialogueManager,

--- a/src/bot/TelegramBot.ts
+++ b/src/bot/TelegramBot.ts
@@ -51,8 +51,8 @@ import {
   CHAT_REPOSITORY_ID,
   type ChatRepository,
 } from '../domain/repositories/ChatRepository.interface';
+import { TriggerContext } from '../domain/triggers/Trigger.interface';
 import { registerRoutes } from '../infrastructure/telegramRouter';
-import { TriggerContext } from '../triggers/Trigger.interface';
 import { createWindows, type WindowId } from './windowConfig';
 
 export async function withTyping(

--- a/src/domain/triggers/Trigger.interface.ts
+++ b/src/domain/triggers/Trigger.interface.ts
@@ -1,6 +1,7 @@
+import type { ServiceIdentifier } from 'inversify';
 import type { Context } from 'telegraf';
 
-import type { DialogueManager } from '../application/interfaces/chat/DialogueManager.interface';
+import type { DialogueManager } from '../../application/interfaces/chat/DialogueManager.interface';
 
 export interface TriggerContext {
   text: string;
@@ -25,3 +26,6 @@ export interface Trigger {
     dialogue: DialogueManager
   ): Promise<TriggerResult | null>;
 }
+
+// eslint-disable-next-line import/no-unused-modules
+export const TRIGGER_ID = Symbol.for('Trigger') as ServiceIdentifier<Trigger>;

--- a/src/triggers/InterestTrigger.ts
+++ b/src/triggers/InterestTrigger.ts
@@ -8,7 +8,7 @@ import type {
   Trigger,
   TriggerContext,
   TriggerResult,
-} from './Trigger.interface';
+} from '../domain/triggers/Trigger.interface';
 
 export class InterestTrigger implements Trigger {
   private readonly logger: Logger;

--- a/src/triggers/MentionTrigger.ts
+++ b/src/triggers/MentionTrigger.ts
@@ -7,7 +7,7 @@ import type {
   Trigger,
   TriggerContext,
   TriggerResult,
-} from './Trigger.interface';
+} from '../domain/triggers/Trigger.interface';
 
 export class MentionTrigger implements Trigger {
   private readonly logger: Logger;

--- a/src/triggers/NameTrigger.ts
+++ b/src/triggers/NameTrigger.ts
@@ -7,7 +7,7 @@ import type {
   Trigger,
   TriggerContext,
   TriggerResult,
-} from './Trigger.interface';
+} from '../domain/triggers/Trigger.interface';
 
 export class NameTrigger implements Trigger {
   private pattern: RegExp;

--- a/src/triggers/ReplyTrigger.ts
+++ b/src/triggers/ReplyTrigger.ts
@@ -7,7 +7,7 @@ import type {
   Trigger,
   TriggerContext,
   TriggerResult,
-} from './Trigger.interface';
+} from '../domain/triggers/Trigger.interface';
 
 export class ReplyTrigger implements Trigger {
   private readonly logger: Logger;

--- a/test/ChatResponder.test.ts
+++ b/test/ChatResponder.test.ts
@@ -9,7 +9,7 @@ import type { ChatMemoryManager } from '../src/application/interfaces/chat/ChatM
 import { ChatResponder } from '../src/application/interfaces/chat/ChatResponder.interface';
 import { DefaultChatResponder } from '../src/application/use-cases/chat/DefaultChatResponder';
 import type { SummaryService } from '../src/application/interfaces/summaries/SummaryService.interface';
-import { TriggerReason } from '../src/triggers/Trigger.interface';
+import { TriggerReason } from '../src/domain/triggers/Trigger.interface';
 import type { LoggerFactory } from '../src/application/interfaces/logging/LoggerFactory.interface';
 
 class MockAIService implements AIService {

--- a/test/InterestTrigger.test.ts
+++ b/test/InterestTrigger.test.ts
@@ -5,7 +5,7 @@ import { DefaultDialogueManager } from '../src/application/use-cases/chat/Defaul
 import { DialogueManager } from '../src/application/interfaces/chat/DialogueManager.interface';
 import { InterestChecker } from '../src/application/interfaces/interest/InterestChecker.interface';
 import { InterestTrigger } from '../src/triggers/InterestTrigger';
-import { TriggerContext } from '../src/triggers/Trigger.interface';
+import { TriggerContext } from '../src/domain/triggers/Trigger.interface';
 import type { LoggerFactory } from '../src/application/interfaces/logging/LoggerFactory.interface';
 
 class MockInterestChecker implements InterestChecker {

--- a/test/TriggerPipeline.test.ts
+++ b/test/TriggerPipeline.test.ts
@@ -9,7 +9,7 @@ import { InterestChecker } from '../src/application/interfaces/interest/Interest
 import {
   type Trigger,
   TriggerContext,
-} from '../src/triggers/Trigger.interface';
+} from '../src/domain/triggers/Trigger.interface';
 import type { LoggerFactory } from '../src/application/interfaces/logging/LoggerFactory.interface';
 
 describe('TriggerPipeline', () => {

--- a/test/Triggers.test.ts
+++ b/test/Triggers.test.ts
@@ -6,7 +6,7 @@ import { TestEnvService } from '../src/application/use-cases/env/TestEnvService'
 import { MentionTrigger } from '../src/triggers/MentionTrigger';
 import { NameTrigger } from '../src/triggers/NameTrigger';
 import { ReplyTrigger } from '../src/triggers/ReplyTrigger';
-import { TriggerContext } from '../src/triggers/Trigger.interface';
+import { TriggerContext } from '../src/domain/triggers/Trigger.interface';
 import type { LoggerFactory } from '../src/application/interfaces/logging/LoggerFactory.interface';
 
 const createLoggerFactory = (): LoggerFactory =>

--- a/test/integration/setup.ts
+++ b/test/integration/setup.ts
@@ -14,7 +14,7 @@ import {
   AI_SERVICE_ID,
   type ChatMessage,
 } from '../../src/application/interfaces/ai/AIService.interface';
-import type { TriggerReason } from '../../src/triggers/Trigger.interface';
+import type { TriggerReason } from '../../src/domain/triggers/Trigger.interface';
 import type { Context, Telegram } from 'telegraf';
 
 // Stable mock for AIService


### PR DESCRIPTION
## Summary
- move Trigger interface into domain layer and export TRIGGER_ID
- update imports to new domain trigger path
- drop old Trigger.interface from triggers directory

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a7cef031d08327969b569af53f6b2f