### PR TITLE
Refactor trigger injection via Inversify

### DIFF
--- a/src/application/use-cases/chat/DefaultTriggerPipeline.ts
+++ b/src/application/use-cases/chat/DefaultTriggerPipeline.ts
@@ -1,27 +1,17 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, multiInject } from 'inversify';
 import { Context } from 'telegraf';
 
 import {
+  type Trigger,
+  TRIGGER_ID,
   TriggerContext,
   TriggerResult,
 } from '../../../domain/triggers/Trigger.interface';
-import { InterestTrigger } from '../../../triggers/InterestTrigger';
-import { MentionTrigger } from '../../../triggers/MentionTrigger';
-import { NameTrigger } from '../../../triggers/NameTrigger';
-import { ReplyTrigger } from '../../../triggers/ReplyTrigger';
 import {
   DIALOGUE_MANAGER_ID,
   type DialogueManager,
 } from '../../interfaces/chat/DialogueManager.interface';
 import { type TriggerPipeline } from '../../interfaces/chat/TriggerPipeline.interface';
-import {
-  ENV_SERVICE_ID,
-  EnvService,
-} from '../../interfaces/env/EnvService.interface';
-import {
-  INTEREST_CHECKER_ID,
-  InterestChecker,
-} from '../../interfaces/interest/InterestChecker.interface';
 import type { Logger } from '../../interfaces/logging/Logger.interface';
 import {
   LOGGER_FACTORY_ID,
@@ -30,23 +20,14 @@ import {
 
 @injectable()
 export class DefaultTriggerPipeline implements TriggerPipeline {
-  private mentionTrigger: MentionTrigger;
-  private replyTrigger: ReplyTrigger;
-  private nameTrigger: NameTrigger;
-  private interestTrigger: InterestTrigger;
   private readonly logger: Logger;
 
   constructor(
-    @inject(ENV_SERVICE_ID) envService: EnvService,
-    @inject(INTEREST_CHECKER_ID) interestChecker: InterestChecker,
     @inject(DIALOGUE_MANAGER_ID) private dialogue: DialogueManager,
+    @multiInject(TRIGGER_ID) private triggers: Trigger[],
     @inject(LOGGER_FACTORY_ID) loggerFactory: LoggerFactory
   ) {
     this.logger = loggerFactory.create('DefaultTriggerPipeline');
-    this.nameTrigger = new NameTrigger(envService.getBotName(), loggerFactory);
-    this.interestTrigger = new InterestTrigger(interestChecker, loggerFactory);
-    this.mentionTrigger = new MentionTrigger(loggerFactory);
-    this.replyTrigger = new ReplyTrigger(loggerFactory);
   }
 
   async shouldRespond(
@@ -56,31 +37,13 @@ export class DefaultTriggerPipeline implements TriggerPipeline {
     const chatId = context.chatId;
     const inDialogue = this.dialogue.isActive(chatId);
     let matchedTrigger: string | null = null;
-    let result: TriggerResult | null = await this.mentionTrigger.apply(
-      ctx,
-      context,
-      this.dialogue
-    );
-    if (result) {
-      matchedTrigger = 'MentionTrigger';
-    } else {
-      result = await this.replyTrigger.apply(ctx, context, this.dialogue);
+    let result: TriggerResult | null = null;
+
+    for (const trigger of this.triggers) {
+      result = await trigger.apply(ctx, context, this.dialogue);
       if (result) {
-        matchedTrigger = 'ReplyTrigger';
-      } else {
-        result = await this.nameTrigger.apply(ctx, context, this.dialogue);
-        if (result) {
-          matchedTrigger = 'NameTrigger';
-        } else {
-          result = await this.interestTrigger.apply(
-            ctx,
-            context,
-            this.dialogue
-          );
-          if (result) {
-            matchedTrigger = 'InterestTrigger';
-          }
-        }
+        matchedTrigger = trigger.constructor.name;
+        break;
       }
     }
 

--- a/src/container.ts
+++ b/src/container.ts
@@ -129,6 +129,7 @@ import {
   USER_REPOSITORY_ID,
   type UserRepository,
 } from './domain/repositories/UserRepository.interface';
+import { type Trigger, TRIGGER_ID } from './domain/triggers/Trigger.interface';
 import { PinoLoggerFactory } from './infrastructure/logging/PinoLoggerFactory';
 import { SQLiteDbProviderImpl } from './infrastructure/repositories/DbProvider';
 import { SQLiteAccessKeyRepository } from './infrastructure/repositories/SQLiteAccessKeyRepository';
@@ -139,6 +140,10 @@ import { SQLiteChatUserRepository } from './infrastructure/repositories/SQLiteCh
 import { SQLiteMessageRepository } from './infrastructure/repositories/SQLiteMessageRepository';
 import { SQLiteSummaryRepository } from './infrastructure/repositories/SQLiteSummaryRepository';
 import { SQLiteUserRepository } from './infrastructure/repositories/SQLiteUserRepository';
+import { InterestTrigger } from './triggers/InterestTrigger';
+import { MentionTrigger } from './triggers/MentionTrigger';
+import { NameTrigger } from './triggers/NameTrigger';
+import { ReplyTrigger } from './triggers/ReplyTrigger';
 
 export const container = new Container();
 
@@ -254,6 +259,11 @@ container
   .bind<MessageContextExtractor>(MESSAGE_CONTEXT_EXTRACTOR_ID)
   .to(DefaultMessageContextExtractor)
   .inSingletonScope();
+
+container.bind<Trigger>(TRIGGER_ID).to(MentionTrigger).inSingletonScope();
+container.bind<Trigger>(TRIGGER_ID).to(ReplyTrigger).inSingletonScope();
+container.bind<Trigger>(TRIGGER_ID).to(NameTrigger).inSingletonScope();
+container.bind<Trigger>(TRIGGER_ID).to(InterestTrigger).inSingletonScope();
 
 container
   .bind<TriggerPipeline>(TRIGGER_PIPELINE_ID)

--- a/src/triggers/InterestTrigger.ts
+++ b/src/triggers/InterestTrigger.ts
@@ -1,20 +1,28 @@
+import { inject, injectable } from 'inversify';
 import type { Context } from 'telegraf';
 
 import type { DialogueManager } from '../application/interfaces/chat/DialogueManager.interface';
-import type { InterestChecker } from '../application/interfaces/interest/InterestChecker.interface';
+import {
+  INTEREST_CHECKER_ID,
+  type InterestChecker,
+} from '../application/interfaces/interest/InterestChecker.interface';
 import type { Logger } from '../application/interfaces/logging/Logger.interface';
-import { type LoggerFactory } from '../application/interfaces/logging/LoggerFactory.interface';
+import {
+  LOGGER_FACTORY_ID,
+  type LoggerFactory,
+} from '../application/interfaces/logging/LoggerFactory.interface';
 import type {
   Trigger,
   TriggerContext,
   TriggerResult,
 } from '../domain/triggers/Trigger.interface';
 
+@injectable()
 export class InterestTrigger implements Trigger {
   private readonly logger: Logger;
   constructor(
-    private checker: InterestChecker,
-    loggerFactory: LoggerFactory
+    @inject(INTEREST_CHECKER_ID) private checker: InterestChecker,
+    @inject(LOGGER_FACTORY_ID) loggerFactory: LoggerFactory
   ) {
     this.logger = loggerFactory.create('InterestTrigger');
   }

--- a/src/triggers/MentionTrigger.ts
+++ b/src/triggers/MentionTrigger.ts
@@ -1,17 +1,22 @@
+import { inject, injectable } from 'inversify';
 import type { Context } from 'telegraf';
 
 import type { DialogueManager } from '../application/interfaces/chat/DialogueManager.interface';
 import type { Logger } from '../application/interfaces/logging/Logger.interface';
-import { type LoggerFactory } from '../application/interfaces/logging/LoggerFactory.interface';
+import {
+  LOGGER_FACTORY_ID,
+  type LoggerFactory,
+} from '../application/interfaces/logging/LoggerFactory.interface';
 import type {
   Trigger,
   TriggerContext,
   TriggerResult,
 } from '../domain/triggers/Trigger.interface';
 
+@injectable()
 export class MentionTrigger implements Trigger {
   private readonly logger: Logger;
-  constructor(loggerFactory: LoggerFactory) {
+  constructor(@inject(LOGGER_FACTORY_ID) loggerFactory: LoggerFactory) {
     this.logger = loggerFactory.create('MentionTrigger');
   }
   async apply(

--- a/src/triggers/NameTrigger.ts
+++ b/src/triggers/NameTrigger.ts
@@ -1,19 +1,31 @@
+import { inject, injectable } from 'inversify';
 import type { Context } from 'telegraf';
 
 import type { DialogueManager } from '../application/interfaces/chat/DialogueManager.interface';
+import {
+  ENV_SERVICE_ID,
+  type EnvService,
+} from '../application/interfaces/env/EnvService.interface';
 import type { Logger } from '../application/interfaces/logging/Logger.interface';
-import { type LoggerFactory } from '../application/interfaces/logging/LoggerFactory.interface';
+import {
+  LOGGER_FACTORY_ID,
+  type LoggerFactory,
+} from '../application/interfaces/logging/LoggerFactory.interface';
 import type {
   Trigger,
   TriggerContext,
   TriggerResult,
 } from '../domain/triggers/Trigger.interface';
 
+@injectable()
 export class NameTrigger implements Trigger {
   private pattern: RegExp;
   private readonly logger: Logger;
-  constructor(name: string, loggerFactory: LoggerFactory) {
-    this.pattern = new RegExp(`^${name}[,:\\s]`, 'i');
+  constructor(
+    @inject(ENV_SERVICE_ID) envService: EnvService,
+    @inject(LOGGER_FACTORY_ID) loggerFactory: LoggerFactory
+  ) {
+    this.pattern = new RegExp(`^${envService.getBotName()}[,:\\s]`, 'i');
     this.logger = loggerFactory.create('NameTrigger');
     this.logger.debug(
       { pattern: this.pattern },

--- a/src/triggers/ReplyTrigger.ts
+++ b/src/triggers/ReplyTrigger.ts
@@ -1,17 +1,22 @@
+import { inject, injectable } from 'inversify';
 import type { Context } from 'telegraf';
 
 import type { DialogueManager } from '../application/interfaces/chat/DialogueManager.interface';
 import type { Logger } from '../application/interfaces/logging/Logger.interface';
-import { type LoggerFactory } from '../application/interfaces/logging/LoggerFactory.interface';
+import {
+  LOGGER_FACTORY_ID,
+  type LoggerFactory,
+} from '../application/interfaces/logging/LoggerFactory.interface';
 import type {
   Trigger,
   TriggerContext,
   TriggerResult,
 } from '../domain/triggers/Trigger.interface';
 
+@injectable()
 export class ReplyTrigger implements Trigger {
   private readonly logger: Logger;
-  constructor(loggerFactory: LoggerFactory) {
+  constructor(@inject(LOGGER_FACTORY_ID) loggerFactory: LoggerFactory) {
     this.logger = loggerFactory.create('ReplyTrigger');
   }
   async apply(

--- a/test/Triggers.test.ts
+++ b/test/Triggers.test.ts
@@ -8,6 +8,7 @@ import { NameTrigger } from '../src/triggers/NameTrigger';
 import { ReplyTrigger } from '../src/triggers/ReplyTrigger';
 import { TriggerContext } from '../src/domain/triggers/Trigger.interface';
 import type { LoggerFactory } from '../src/application/interfaces/logging/LoggerFactory.interface';
+import type { EnvService } from '../src/application/interfaces/env/EnvService.interface';
 
 const createLoggerFactory = (): LoggerFactory =>
   ({
@@ -102,7 +103,10 @@ describe('MentionTrigger', () => {
 });
 
 describe('NameTrigger', () => {
-  const trigger = new NameTrigger('Arkadius', createLoggerFactory());
+  const envService = {
+    getBotName: () => 'Arkadius',
+  } as unknown as EnvService;
+  const trigger = new NameTrigger(envService, createLoggerFactory());
 
   it('recognizes name at start of text', async () => {
     const ctx: TriggerContext = {


### PR DESCRIPTION
## Summary
- inject InterestTrigger, MentionTrigger, NameTrigger, and ReplyTrigger with `@injectable` and proper `@inject` constructors
- bind triggers to `TRIGGER_ID` and resolve them in DefaultTriggerPipeline via `@multiInject`
- streamline DefaultTriggerPipeline to iterate injected triggers sequentially

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a83d7508708327aa6006b04fbd1ad1