### PR TITLE
Refactor trigger dialogue management

### DIFF
--- a/src/application/use-cases/chat/DefaultTriggerPipeline.ts
+++ b/src/application/use-cases/chat/DefaultTriggerPipeline.ts
@@ -40,7 +40,7 @@ export class DefaultTriggerPipeline implements TriggerPipeline {
     let result: TriggerResult | null = null;
 
     for (const trigger of this.triggers) {
-      result = await trigger.apply(ctx, context, this.dialogue);
+      result = await trigger.apply(ctx, context);
       if (result) {
         matchedTrigger = trigger.constructor.name;
         break;

--- a/src/domain/triggers/Trigger.interface.ts
+++ b/src/domain/triggers/Trigger.interface.ts
@@ -1,8 +1,6 @@
 import type { ServiceIdentifier } from 'inversify';
 import type { Context } from 'telegraf';
 
-import type { DialogueManager } from '../../application/interfaces/chat/DialogueManager.interface';
-
 export interface TriggerContext {
   text: string;
   replyText: string;
@@ -20,12 +18,7 @@ export interface TriggerResult {
 }
 
 export interface Trigger {
-  apply(
-    ctx: Context,
-    context: TriggerContext,
-    dialogue: DialogueManager
-  ): Promise<TriggerResult | null>;
+  apply(ctx: Context, context: TriggerContext): Promise<TriggerResult | null>;
 }
 
-// eslint-disable-next-line import/no-unused-modules
 export const TRIGGER_ID = Symbol.for('Trigger') as ServiceIdentifier<Trigger>;

--- a/src/triggers/InterestTrigger.ts
+++ b/src/triggers/InterestTrigger.ts
@@ -1,7 +1,10 @@
 import { inject, injectable } from 'inversify';
 import type { Context } from 'telegraf';
 
-import type { DialogueManager } from '../application/interfaces/chat/DialogueManager.interface';
+import {
+  DIALOGUE_MANAGER_ID,
+  type DialogueManager,
+} from '../application/interfaces/chat/DialogueManager.interface';
 import {
   INTEREST_CHECKER_ID,
   type InterestChecker,
@@ -22,6 +25,7 @@ export class InterestTrigger implements Trigger {
   private readonly logger: Logger;
   constructor(
     @inject(INTEREST_CHECKER_ID) private checker: InterestChecker,
+    @inject(DIALOGUE_MANAGER_ID) private dialogue: DialogueManager,
     @inject(LOGGER_FACTORY_ID) loggerFactory: LoggerFactory
   ) {
     this.logger = loggerFactory.create('InterestTrigger');
@@ -29,10 +33,9 @@ export class InterestTrigger implements Trigger {
 
   async apply(
     _ctx: Context,
-    { chatId }: TriggerContext,
-    dialogue: DialogueManager
+    { chatId }: TriggerContext
   ): Promise<TriggerResult | null> {
-    if (dialogue.isActive(chatId)) {
+    if (this.dialogue.isActive(chatId)) {
       this.logger.debug(
         { chatId },
         'Interest trigger suppressed because dialogue is active'

--- a/src/triggers/NameTrigger.ts
+++ b/src/triggers/NameTrigger.ts
@@ -1,7 +1,6 @@
 import { inject, injectable } from 'inversify';
 import type { Context } from 'telegraf';
 
-import type { DialogueManager } from '../application/interfaces/chat/DialogueManager.interface';
 import {
   ENV_SERVICE_ID,
   type EnvService,
@@ -33,9 +32,8 @@ export class NameTrigger implements Trigger {
     );
   }
   async apply(
-    ctx: Context,
-    context: TriggerContext,
-    _dialogue: DialogueManager
+    _ctx: Context,
+    context: TriggerContext
   ): Promise<TriggerResult | null> {
     const text = context.text;
     if (this.pattern.test(text)) {

--- a/src/triggers/ReplyTrigger.ts
+++ b/src/triggers/ReplyTrigger.ts
@@ -1,7 +1,6 @@
 import { inject, injectable } from 'inversify';
 import type { Context } from 'telegraf';
 
-import type { DialogueManager } from '../application/interfaces/chat/DialogueManager.interface';
 import type { Logger } from '../application/interfaces/logging/Logger.interface';
 import {
   LOGGER_FACTORY_ID,
@@ -21,8 +20,7 @@ export class ReplyTrigger implements Trigger {
   }
   async apply(
     ctx: Context,
-    context: TriggerContext,
-    _dialogue: DialogueManager
+    context: TriggerContext
   ): Promise<TriggerResult | null> {
     const msg = ctx.message as
       | {

--- a/test/InterestTrigger.test.ts
+++ b/test/InterestTrigger.test.ts
@@ -2,7 +2,7 @@ import type { Context } from 'telegraf';
 import { describe, expect, it, vi } from 'vitest';
 
 import { DefaultDialogueManager } from '../src/application/use-cases/chat/DefaultDialogueManager';
-import { DialogueManager } from '../src/application/interfaces/chat/DialogueManager.interface';
+import type { DialogueManager } from '../src/application/interfaces/chat/DialogueManager.interface';
 import { InterestChecker } from '../src/application/interfaces/interest/InterestChecker.interface';
 import { InterestTrigger } from '../src/triggers/InterestTrigger';
 import { TriggerContext } from '../src/domain/triggers/Trigger.interface';
@@ -55,13 +55,10 @@ describe('InterestTrigger', () => {
         message: 'hi',
         why: 'because',
       }),
+      dialogue,
       loggerFactory
     );
-    const res = await trigger.apply(
-      {} as unknown as Context,
-      baseCtx,
-      dialogue
-    );
+    const res = await trigger.apply({} as unknown as Context, baseCtx);
     expect(res).toBeNull();
   });
 
@@ -72,14 +69,11 @@ describe('InterestTrigger', () => {
         message: 'hi',
         why: 'because',
       }),
+      dialogue,
       loggerFactory
     );
-    await trigger.apply({} as unknown as Context, baseCtx, dialogue);
-    const res = await trigger.apply(
-      {} as unknown as Context,
-      baseCtx,
-      dialogue
-    );
+    await trigger.apply({} as unknown as Context, baseCtx);
+    const res = await trigger.apply({} as unknown as Context, baseCtx);
     expect(res).not.toBeNull();
     expect(res?.replyToMessageId).toBe(1);
     expect(res?.reason?.why).toBe('because');
@@ -89,14 +83,11 @@ describe('InterestTrigger', () => {
   it('returns null when checker reports not interested', async () => {
     const trigger = new InterestTrigger(
       new MockInterestChecker(2, null),
+      dialogue,
       loggerFactory
     );
-    await trigger.apply({} as unknown as Context, baseCtx, dialogue);
-    const res = await trigger.apply(
-      {} as unknown as Context,
-      baseCtx,
-      dialogue
-    );
+    await trigger.apply({} as unknown as Context, baseCtx);
+    const res = await trigger.apply({} as unknown as Context, baseCtx);
     expect(res).toBeNull();
   });
 
@@ -106,17 +97,13 @@ describe('InterestTrigger', () => {
       message: 'hi',
       why: 'because',
     });
-    const trigger = new InterestTrigger(checker, loggerFactory);
     const activeDialogue: DialogueManager = new DefaultDialogueManager(
       { getDialogueTimeoutMs: () => 0 } as any,
       loggerFactory
     );
+    const trigger = new InterestTrigger(checker, activeDialogue, loggerFactory);
     activeDialogue.start(baseCtx.chatId);
-    const res = await trigger.apply(
-      {} as unknown as Context,
-      baseCtx,
-      activeDialogue
-    );
+    const res = await trigger.apply({} as unknown as Context, baseCtx);
     expect(res).toBeNull();
     expect(checker.calls).toBe(0);
   });

--- a/test/TriggerPipeline.test.ts
+++ b/test/TriggerPipeline.test.ts
@@ -35,14 +35,14 @@ describe('TriggerPipeline', () => {
   const createPipeline = (
     interestChecker: InterestChecker,
     logger: LoggerFactory = loggerFactory,
-    triggers?: Trigger[]
+    triggers?: (dialogue: DialogueManager) => Trigger[]
   ): { pipeline: TriggerPipeline; dialogue: DialogueManager } => {
     const dialogue: DialogueManager = new DefaultDialogueManager(env, logger);
-    const defaultTriggers: Trigger[] = triggers ?? [
-      new MentionTrigger(logger),
+    const defaultTriggers: Trigger[] = triggers?.(dialogue) ?? [
+      new MentionTrigger(dialogue, logger),
       new ReplyTrigger(logger),
       new NameTrigger(env, logger),
-      new InterestTrigger(interestChecker, logger),
+      new InterestTrigger(interestChecker, dialogue, logger),
     ];
     const pipeline = new DefaultTriggerPipeline(
       dialogue,
@@ -123,16 +123,15 @@ describe('TriggerPipeline', () => {
         .fn()
         .mockResolvedValue({ messageId: '1', message: 'hi', why: 'because' }),
     };
-    const triggers: Trigger[] = [
-      { apply: vi.fn().mockResolvedValue(null) },
-      { apply: vi.fn().mockResolvedValue(null) },
-      new NameTrigger(env, loggerFactory),
-      new InterestTrigger(interestChecker, loggerFactory),
-    ];
     const { pipeline } = createPipeline(
       interestChecker,
       loggerFactory,
-      triggers
+      (dialogue) => [
+        { apply: vi.fn().mockResolvedValue(null) },
+        { apply: vi.fn().mockResolvedValue(null) },
+        new NameTrigger(env, loggerFactory),
+        new InterestTrigger(interestChecker, dialogue, loggerFactory),
+      ]
     );
     const ctx = {
       message: { text: 'hi @bot', reply_to_message: { message_id: 2 } },

--- a/test/Triggers.test.ts
+++ b/test/Triggers.test.ts
@@ -22,19 +22,23 @@ const createLoggerFactory = (): LoggerFactory =>
   }) as unknown as LoggerFactory;
 
 describe('MentionTrigger', () => {
-  const trigger = new MentionTrigger(createLoggerFactory());
+  const createMentionTrigger = (loggerFactory = createLoggerFactory()) => {
+    const dialogue = new DefaultDialogueManager(
+      new TestEnvService(),
+      createLoggerFactory()
+    );
+    const trigger = new MentionTrigger(dialogue, loggerFactory);
+    return { trigger, dialogue };
+  };
 
   it('removes bot mention and returns result', async () => {
+    const { trigger } = createMentionTrigger();
     const ctx: TriggerContext = { text: '', replyText: '', chatId: 1 };
     const telegrafCtx = {
       message: { text: 'hello @bot' },
       me: 'bot',
     } as unknown as Context;
-    const res = await trigger.apply(
-      telegrafCtx,
-      ctx,
-      new DefaultDialogueManager(new TestEnvService(), createLoggerFactory())
-    );
+    const res = await trigger.apply(telegrafCtx, ctx);
     expect(res).not.toBeNull();
     expect(res?.replyToMessageId).toBeNull();
     expect(res?.reason).toBeNull();
@@ -42,28 +46,22 @@ describe('MentionTrigger', () => {
   });
 
   it('returns null without mention', async () => {
+    const { trigger } = createMentionTrigger();
     const ctx: TriggerContext = { text: '', replyText: '', chatId: 1 };
     const telegrafCtx = {
       message: { text: 'hello there' },
       me: 'bot',
     } as unknown as Context;
-    const res = await trigger.apply(
-      telegrafCtx,
-      ctx,
-      new DefaultDialogueManager(new TestEnvService(), createLoggerFactory())
-    );
+    const res = await trigger.apply(telegrafCtx, ctx);
     expect(res).toBeNull();
     expect(ctx.text).toBe('');
   });
 
   it('handles non-string fields gracefully', async () => {
+    const { trigger } = createMentionTrigger();
     const ctx: TriggerContext = { text: '', replyText: '', chatId: 1 };
     const telegrafCtx = { message: {}, me: undefined } as unknown as Context;
-    const res = await trigger.apply(
-      telegrafCtx,
-      ctx,
-      new DefaultDialogueManager(new TestEnvService(), createLoggerFactory())
-    );
+    const res = await trigger.apply(telegrafCtx, ctx);
     expect(res).toBeNull();
     expect(ctx.text).toBe('');
   });
@@ -79,18 +77,15 @@ describe('MentionTrigger', () => {
         child: vi.fn(),
       }),
     } as unknown as LoggerFactory;
-    const triggerWithLogger = new MentionTrigger(loggerFactory);
+    const { trigger: triggerWithLogger, dialogue } =
+      createMentionTrigger(loggerFactory);
     const ctx: TriggerContext = { text: '', replyText: '', chatId: 1 };
     const telegrafCtx = {
       message: { text: 'hello there @bot how are you doing?' },
       me: 'bot',
     } as unknown as Context;
-    const dialogue = new DefaultDialogueManager(
-      new TestEnvService(),
-      createLoggerFactory()
-    );
     dialogue.start(1);
-    await triggerWithLogger.apply(telegrafCtx, ctx, dialogue);
+    await triggerWithLogger.apply(telegrafCtx, ctx);
     expect(debug).toHaveBeenCalledWith(
       expect.objectContaining({
         chatId: 1,
@@ -114,11 +109,7 @@ describe('NameTrigger', () => {
       replyText: '',
       chatId: 1,
     };
-    const res = await trigger.apply(
-      {} as unknown as Context,
-      ctx,
-      new DefaultDialogueManager(new TestEnvService(), createLoggerFactory())
-    );
+    const res = await trigger.apply({} as unknown as Context, ctx);
     expect(res).not.toBeNull();
     expect(ctx.text).toBe('how are you?');
   });
@@ -129,11 +120,7 @@ describe('NameTrigger', () => {
       replyText: '',
       chatId: 1,
     };
-    const res = await trigger.apply(
-      {} as unknown as Context,
-      ctx,
-      new DefaultDialogueManager(new TestEnvService(), createLoggerFactory())
-    );
+    const res = await trigger.apply({} as unknown as Context, ctx);
     expect(res).toBeNull();
     expect(ctx.text).toBe('Hello Arkadius');
   });
@@ -148,22 +135,14 @@ describe('ReplyTrigger', () => {
       me: 'bot',
       message: { reply_to_message: { from: { username: 'bot' } } },
     } as unknown as Context;
-    const res = await trigger.apply(
-      telegrafCtx,
-      ctx,
-      new DefaultDialogueManager(new TestEnvService(), createLoggerFactory())
-    );
+    const res = await trigger.apply(telegrafCtx, ctx);
     expect(res).not.toBeNull();
   });
 
   it('returns null when not replying to bot', async () => {
     const ctx: TriggerContext = { text: '', replyText: '', chatId: 1 };
     const telegrafCtx = { me: 'bot', message: {} } as unknown as Context;
-    const res = await trigger.apply(
-      telegrafCtx,
-      ctx,
-      new DefaultDialogueManager(new TestEnvService(), createLoggerFactory())
-    );
+    const res = await trigger.apply(telegrafCtx, ctx);
     expect(res).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- simplify Trigger.apply to accept only Context and TriggerContext
- inject DialogueManager into triggers that need it
- update DefaultTriggerPipeline and tests for new trigger interface

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a83fbef6d88327aafb13a93d58f5c5