### PR TITLE
feat: enforce layer import boundaries

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -85,6 +85,22 @@ module.exports = [
         },
       ],
       'import/no-default-export': 'error',
+      'import/no-restricted-paths': [
+        'error',
+        {
+          zones: [
+            {
+              target: ['src/domain'],
+              from: ['src/application', 'src/infrastructure', 'src/interface'],
+            },
+            {
+              target: ['src/application'],
+              from: ['src/infrastructure', 'src/interface'],
+            },
+            { target: ['src/infrastructure'], from: ['src/interface'] },
+          ],
+        },
+      ],
     },
     settings: {
       'import/extensions': ['.js', '.ts'],

--- a/src/application/interfaces/ai/AIService.interface.ts
+++ b/src/application/interfaces/ai/AIService.interface.ts
@@ -1,17 +1,4 @@
-export interface ChatMessage {
-  role: 'user' | 'assistant';
-  content: string;
-  username?: string;
-  fullName?: string;
-  replyText?: string;
-  replyUsername?: string;
-  quoteText?: string;
-  userId?: number;
-  messageId?: number;
-  chatId?: number;
-  attitude?: string | null;
-}
-
+import type { ChatMessage } from '../../../domain/messages/ChatMessage.interface';
 import type { TriggerReason } from '../../../domain/triggers/Trigger.interface';
 
 export interface AIService {

--- a/src/application/interfaces/chat/ChatMemory.interface.ts
+++ b/src/application/interfaces/chat/ChatMemory.interface.ts
@@ -1,5 +1,5 @@
-import type { ChatMessage } from '../ai/AIService.interface';
-import type { StoredMessage } from '../messages/StoredMessage.interface';
+import type { ChatMessage } from '../../../domain/messages/ChatMessage.interface';
+import type { StoredMessage } from '../../../domain/messages/StoredMessage.interface';
 
 export interface ChatMemory {
   addMessage(message: StoredMessage): Promise<void>;

--- a/src/application/interfaces/chat/HistorySummarizer.interface.ts
+++ b/src/application/interfaces/chat/HistorySummarizer.interface.ts
@@ -1,6 +1,6 @@
 import type { ServiceIdentifier } from 'inversify';
 
-import type { ChatMessage } from '../ai/AIService.interface';
+import type { ChatMessage } from '../../../domain/messages/ChatMessage.interface';
 
 export interface HistorySummarizer {
   summarize(

--- a/src/application/interfaces/messages/InterestMessageStore.interface.ts
+++ b/src/application/interfaces/messages/InterestMessageStore.interface.ts
@@ -1,7 +1,7 @@
 import type { ServiceIdentifier } from 'inversify';
 
-import type { ChatMessage } from '../ai/AIService.interface';
-import type { StoredMessage } from './StoredMessage.interface';
+import type { ChatMessage } from '../../../domain/messages/ChatMessage.interface';
+import type { StoredMessage } from '../../../domain/messages/StoredMessage.interface';
 
 export interface InterestMessageStore {
   addMessage(msg: StoredMessage): void;

--- a/src/application/interfaces/messages/MessageService.interface.ts
+++ b/src/application/interfaces/messages/MessageService.interface.ts
@@ -1,7 +1,7 @@
 import type { ServiceIdentifier } from 'inversify';
 
-import type { ChatMessage } from '../ai/AIService.interface';
-import type { StoredMessage } from './StoredMessage.interface';
+import type { ChatMessage } from '../../../domain/messages/ChatMessage.interface';
+import type { StoredMessage } from '../../../domain/messages/StoredMessage.interface';
 
 export interface MessageService {
   addMessage(message: StoredMessage): Promise<void>;

--- a/src/application/use-cases/admin/AdminServiceImpl.ts
+++ b/src/application/use-cases/admin/AdminServiceImpl.ts
@@ -3,6 +3,7 @@ import { randomBytes } from 'node:crypto';
 import { inject, injectable } from 'inversify';
 
 import type { UserEntity } from '../../../domain/entities/UserEntity';
+import type { ChatMessage } from '../../../domain/messages/ChatMessage.interface';
 import {
   ACCESS_KEY_REPOSITORY_ID,
   type AccessKeyRepository,
@@ -29,7 +30,6 @@ import {
   type UserRepository,
 } from '../../../domain/repositories/UserRepository.interface';
 import { AdminService } from '../../interfaces/admin/AdminService.interface';
-import type { ChatMessage } from '../../interfaces/ai/AIService.interface';
 import {
   CHAT_CONFIG_SERVICE_ID,
   type ChatConfigService,

--- a/src/application/use-cases/chat/ChatMemory.ts
+++ b/src/application/use-cases/chat/ChatMemory.ts
@@ -1,6 +1,7 @@
 import { inject, injectable } from 'inversify';
 
-import { ChatMessage } from '../../interfaces/ai/AIService.interface';
+import type { ChatMessage } from '../../../domain/messages/ChatMessage.interface';
+import { StoredMessage } from '../../../domain/messages/StoredMessage.interface';
 import {
   CHAT_CONFIG_SERVICE_ID,
   type ChatConfigService,
@@ -28,7 +29,6 @@ import {
   MESSAGE_SERVICE_ID,
   type MessageService,
 } from '../../interfaces/messages/MessageService.interface';
-import { StoredMessage } from '../../interfaces/messages/StoredMessage.interface';
 
 @injectable()
 export class ChatMemory implements ChatMemoryInterface {

--- a/src/application/use-cases/chat/DefaultHistorySummarizer.ts
+++ b/src/application/use-cases/chat/DefaultHistorySummarizer.ts
@@ -1,5 +1,6 @@
 import { inject, injectable } from 'inversify';
 
+import type { ChatMessage } from '../../../domain/messages/ChatMessage.interface';
 import {
   USER_REPOSITORY_ID,
   UserRepository,
@@ -7,7 +8,6 @@ import {
 import {
   AI_SERVICE_ID,
   AIService,
-  ChatMessage,
 } from '../../interfaces/ai/AIService.interface';
 import { type HistorySummarizer } from '../../interfaces/chat/HistorySummarizer.interface';
 import type { Logger } from '../../interfaces/logging/Logger.interface';

--- a/src/application/use-cases/interest/DefaultInterestChecker.ts
+++ b/src/application/use-cases/interest/DefaultInterestChecker.ts
@@ -1,9 +1,9 @@
 import { inject, injectable } from 'inversify';
 
+import type { ChatMessage } from '../../../domain/messages/ChatMessage.interface';
 import {
   AI_SERVICE_ID,
   AIService,
-  ChatMessage,
 } from '../../interfaces/ai/AIService.interface';
 import {
   CHAT_CONFIG_SERVICE_ID,

--- a/src/application/use-cases/messages/InMemoryInterestMessageStore.ts
+++ b/src/application/use-cases/messages/InMemoryInterestMessageStore.ts
@@ -1,13 +1,13 @@
 import { inject, injectable } from 'inversify';
 
-import type { ChatMessage } from '../../interfaces/ai/AIService.interface';
+import type { ChatMessage } from '../../../domain/messages/ChatMessage.interface';
+import type { StoredMessage } from '../../../domain/messages/StoredMessage.interface';
 import type { Logger } from '../../interfaces/logging/Logger.interface';
 import {
   LOGGER_FACTORY_ID,
   type LoggerFactory,
 } from '../../interfaces/logging/LoggerFactory.interface';
 import { type InterestMessageStore } from '../../interfaces/messages/InterestMessageStore.interface';
-import type { StoredMessage } from '../../interfaces/messages/StoredMessage.interface';
 
 @injectable()
 export class InMemoryInterestMessageStore implements InterestMessageStore {

--- a/src/application/use-cases/messages/MessageFactory.ts
+++ b/src/application/use-cases/messages/MessageFactory.ts
@@ -2,8 +2,8 @@ import assert from 'node:assert';
 
 import type { Context } from 'telegraf';
 
+import type { StoredMessage } from '../../../domain/messages/StoredMessage.interface';
 import type { MessageContext } from '../../interfaces/messages/MessageContextExtractor.interface';
-import type { StoredMessage } from '../../interfaces/messages/StoredMessage.interface';
 
 export class MessageFactory {
   static fromUser(ctx: Context, meta: MessageContext): StoredMessage {

--- a/src/application/use-cases/messages/RepositoryMessageService.ts
+++ b/src/application/use-cases/messages/RepositoryMessageService.ts
@@ -1,5 +1,7 @@
 import { inject, injectable } from 'inversify';
 
+import type { ChatMessage } from '../../../domain/messages/ChatMessage.interface';
+import { StoredMessage } from '../../../domain/messages/StoredMessage.interface';
 import {
   CHAT_REPOSITORY_ID,
   type ChatRepository,
@@ -16,14 +18,12 @@ import {
   USER_REPOSITORY_ID,
   type UserRepository,
 } from '../../../domain/repositories/UserRepository.interface';
-import type { ChatMessage } from '../../interfaces/ai/AIService.interface';
 import type { Logger } from '../../interfaces/logging/Logger.interface';
 import {
   LOGGER_FACTORY_ID,
   type LoggerFactory,
 } from '../../interfaces/logging/LoggerFactory.interface';
 import { MessageService } from '../../interfaces/messages/MessageService.interface';
-import { StoredMessage } from '../../interfaces/messages/StoredMessage.interface';
 
 @injectable()
 export class RepositoryMessageService implements MessageService {

--- a/src/domain/messages/ChatMessage.interface.ts
+++ b/src/domain/messages/ChatMessage.interface.ts
@@ -1,0 +1,13 @@
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  username?: string;
+  fullName?: string;
+  replyText?: string;
+  replyUsername?: string;
+  quoteText?: string;
+  userId?: number;
+  messageId?: number;
+  chatId?: number;
+  attitude?: string | null;
+}

--- a/src/domain/messages/StoredMessage.interface.ts
+++ b/src/domain/messages/StoredMessage.interface.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage } from '../ai/AIService.interface';
+import type { ChatMessage } from './ChatMessage.interface';
 
 export interface StoredMessage extends ChatMessage {
   chatId: number;

--- a/src/domain/repositories/MessageRepository.interface.ts
+++ b/src/domain/repositories/MessageRepository.interface.ts
@@ -1,7 +1,7 @@
 import type { ServiceIdentifier } from 'inversify';
 
-import type { ChatMessage } from '../../application/interfaces/ai/AIService.interface';
-import type { StoredMessage } from '../../application/interfaces/messages/StoredMessage.interface';
+import type { ChatMessage } from '../messages/ChatMessage.interface';
+import type { StoredMessage } from '../messages/StoredMessage.interface';
 
 export interface MessageRepository {
   insert(message: StoredMessage): Promise<void>;

--- a/src/infrastructure/external/ChatGPTService.ts
+++ b/src/infrastructure/external/ChatGPTService.ts
@@ -4,10 +4,7 @@ import OpenAI from 'openai';
 import { ChatModel } from 'openai/resources/shared';
 import path from 'path';
 
-import {
-  AIService,
-  ChatMessage,
-} from '../../application/interfaces/ai/AIService.interface';
+import { AIService } from '../../application/interfaces/ai/AIService.interface';
 import {
   ENV_SERVICE_ID,
   EnvService,
@@ -21,6 +18,7 @@ import {
   PROMPT_SERVICE_ID,
   PromptService,
 } from '../../application/interfaces/prompts/PromptService.interface';
+import type { ChatMessage } from '../../domain/messages/ChatMessage.interface';
 import { TriggerReason } from '../../domain/triggers/Trigger.interface';
 
 @injectable()

--- a/src/infrastructure/persistence/sqlite/SQLiteMessageRepository.ts
+++ b/src/infrastructure/persistence/sqlite/SQLiteMessageRepository.ts
@@ -1,7 +1,7 @@
 import { inject, injectable } from 'inversify';
 
-import type { ChatMessage } from '../../../application/interfaces/ai/AIService.interface';
-import type { StoredMessage } from '../../../application/interfaces/messages/StoredMessage.interface';
+import type { ChatMessage } from '../../../domain/messages/ChatMessage.interface';
+import type { StoredMessage } from '../../../domain/messages/StoredMessage.interface';
 import {
   DB_PROVIDER_ID,
   type DbProvider,

--- a/test/ChatGPTService.test.ts
+++ b/test/ChatGPTService.test.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { ChatMessage } from '../src/application/interfaces/ai/AIService.interface';
+import type { ChatMessage } from '../src/domain/messages/ChatMessage.interface';
 import type { ChatGPTService as ChatGPTServiceType } from '../src/infrastructure/external/ChatGPTService';
 import { TestEnvService } from '../src/infrastructure/config/TestEnvService';
 import type { PromptService } from '../src/application/interfaces/prompts/PromptService.interface';

--- a/test/ChatMemory.test.ts
+++ b/test/ChatMemory.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ChatMessage } from '../src/application/interfaces/ai/AIService.interface';
+import type { ChatMessage } from '../src/domain/messages/ChatMessage.interface';
 import {
   ChatMemory,
   ChatMemoryManager,
@@ -14,7 +14,7 @@ import {
   InMemoryInterestMessageStore,
 } from '../src/application/use-cases/messages/InMemoryInterestMessageStore';
 import { MessageService } from '../src/application/interfaces/messages/MessageService.interface';
-import { StoredMessage } from '../src/application/interfaces/messages/StoredMessage.interface';
+import { StoredMessage } from '../src/domain/messages/StoredMessage.interface';
 import type { LoggerFactory } from '../src/application/interfaces/logging/LoggerFactory.interface';
 
 const createLoggerFactory = (): LoggerFactory =>

--- a/test/ChatResponder.test.ts
+++ b/test/ChatResponder.test.ts
@@ -1,10 +1,8 @@
 import type { Context } from 'telegraf';
 import { describe, expect, it, vi } from 'vitest';
 
-import type {
-  AIService,
-  ChatMessage,
-} from '../src/application/interfaces/ai/AIService.interface';
+import type { AIService } from '../src/application/interfaces/ai/AIService.interface';
+import type { ChatMessage } from '../src/domain/messages/ChatMessage.interface';
 import type { ChatMemoryManager } from '../src/application/interfaces/chat/ChatMemoryManager.interface';
 import { ChatResponder } from '../src/application/interfaces/chat/ChatResponder.interface';
 import { DefaultChatResponder } from '../src/application/use-cases/chat/DefaultChatResponder';

--- a/test/HistorySummarizer.test.ts
+++ b/test/HistorySummarizer.test.ts
@@ -2,10 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { UserRepository } from '../src/domain/repositories/UserRepository.interface';
 import type { UserEntity } from '../src/domain/entities/UserEntity';
-import type {
-  AIService,
-  ChatMessage,
-} from '../src/application/interfaces/ai/AIService.interface';
+import type { AIService } from '../src/application/interfaces/ai/AIService.interface';
+import type { ChatMessage } from '../src/domain/messages/ChatMessage.interface';
 import { DefaultHistorySummarizer } from '../src/application/use-cases/chat/DefaultHistorySummarizer';
 import type { MessageService } from '../src/application/interfaces/messages/MessageService.interface';
 import type { SummaryService } from '../src/application/interfaces/summaries/SummaryService.interface';

--- a/test/InterestChecker.test.ts
+++ b/test/InterestChecker.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import {
-  AIService,
-  ChatMessage,
-} from '../src/application/interfaces/ai/AIService.interface';
+import type { AIService } from '../src/application/interfaces/ai/AIService.interface';
+import type { ChatMessage } from '../src/domain/messages/ChatMessage.interface';
 import { DefaultInterestChecker } from '../src/application/use-cases/interest/DefaultInterestChecker';
 import { ChatConfigService } from '../src/application/interfaces/chat/ChatConfigService.interface';
 import {

--- a/test/RepositoryMessageService.test.ts
+++ b/test/RepositoryMessageService.test.ts
@@ -5,7 +5,7 @@ import { type ChatUserRepository } from '../src/domain/repositories/ChatUserRepo
 import { type MessageRepository } from '../src/domain/repositories/MessageRepository.interface';
 import { type UserRepository } from '../src/domain/repositories/UserRepository.interface';
 import { RepositoryMessageService } from '../src/application/use-cases/messages/RepositoryMessageService';
-import { type StoredMessage } from '../src/application/interfaces/messages/StoredMessage.interface';
+import { type StoredMessage } from '../src/domain/messages/StoredMessage.interface';
 import type { LoggerFactory } from '../src/application/interfaces/logging/LoggerFactory.interface';
 
 describe('RepositoryMessageService', () => {

--- a/test/integration/setup.ts
+++ b/test/integration/setup.ts
@@ -12,8 +12,8 @@ import { migrateUp } from '../../src/migrate';
 import {
   type AIService,
   AI_SERVICE_ID,
-  type ChatMessage,
 } from '../../src/application/interfaces/ai/AIService.interface';
+import type { ChatMessage } from '../../src/domain/messages/ChatMessage.interface';
 import type { TriggerReason } from '../../src/domain/triggers/Trigger.interface';
 import type { Context, Telegram } from 'telegraf';
 


### PR DESCRIPTION
## Summary
- add ESLint `import/no-restricted-paths` zones to prevent cross-layer imports
- move ChatMessage and StoredMessage interfaces into domain layer and update imports
- remove obsolete application StoredMessage interface

## Testing
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a84b76523c8327b4fa4afc380d4d3a