### PR TITLE
Make trigger interface generic

### DIFF
--- a/src/application/use-cases/chat/DefaultTriggerPipeline.ts
+++ b/src/application/use-cases/chat/DefaultTriggerPipeline.ts
@@ -1,5 +1,5 @@
 import { inject, injectable, multiInject } from 'inversify';
-import { Context } from 'telegraf';
+import type { Context } from 'telegraf';
 
 import {
   type Trigger,
@@ -24,7 +24,7 @@ export class DefaultTriggerPipeline implements TriggerPipeline {
 
   constructor(
     @inject(DIALOGUE_MANAGER_ID) private dialogue: DialogueManager,
-    @multiInject(TRIGGER_ID) private triggers: Trigger[],
+    @multiInject(TRIGGER_ID) private triggers: Trigger<Context>[],
     @inject(LOGGER_FACTORY_ID) loggerFactory: LoggerFactory
   ) {
     this.logger = loggerFactory.create('DefaultTriggerPipeline');

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata';
 
 import { Container } from 'inversify';
+import type { Context } from 'telegraf';
 
 import {
   ADMIN_SERVICE_ID,
@@ -260,10 +261,19 @@ container
   .to(DefaultMessageContextExtractor)
   .inSingletonScope();
 
-container.bind<Trigger>(TRIGGER_ID).to(MentionTrigger).inSingletonScope();
-container.bind<Trigger>(TRIGGER_ID).to(ReplyTrigger).inSingletonScope();
-container.bind<Trigger>(TRIGGER_ID).to(NameTrigger).inSingletonScope();
-container.bind<Trigger>(TRIGGER_ID).to(InterestTrigger).inSingletonScope();
+container
+  .bind<Trigger<Context>>(TRIGGER_ID)
+  .to(MentionTrigger)
+  .inSingletonScope();
+container
+  .bind<Trigger<Context>>(TRIGGER_ID)
+  .to(ReplyTrigger)
+  .inSingletonScope();
+container.bind<Trigger<Context>>(TRIGGER_ID).to(NameTrigger).inSingletonScope();
+container
+  .bind<Trigger<Context>>(TRIGGER_ID)
+  .to(InterestTrigger)
+  .inSingletonScope();
 
 container
   .bind<TriggerPipeline>(TRIGGER_PIPELINE_ID)

--- a/src/domain/triggers/Trigger.interface.ts
+++ b/src/domain/triggers/Trigger.interface.ts
@@ -1,5 +1,4 @@
 import type { ServiceIdentifier } from 'inversify';
-import type { Context } from 'telegraf';
 
 export interface TriggerContext {
   text: string;
@@ -17,8 +16,10 @@ export interface TriggerResult {
   reason: TriggerReason | null;
 }
 
-export interface Trigger {
-  apply(ctx: Context, context: TriggerContext): Promise<TriggerResult | null>;
+export interface Trigger<TCtx = unknown> {
+  apply(ctx: TCtx, context: TriggerContext): Promise<TriggerResult | null>;
 }
 
-export const TRIGGER_ID = Symbol.for('Trigger') as ServiceIdentifier<Trigger>;
+export const TRIGGER_ID = Symbol.for('Trigger') as ServiceIdentifier<
+  Trigger<unknown>
+>;

--- a/src/view/telegram/triggers/InterestTrigger.ts
+++ b/src/view/telegram/triggers/InterestTrigger.ts
@@ -21,7 +21,7 @@ import type {
 } from '../../../domain/triggers/Trigger.interface';
 
 @injectable()
-export class InterestTrigger implements Trigger {
+export class InterestTrigger implements Trigger<Context> {
   private readonly logger: Logger;
   constructor(
     @inject(INTEREST_CHECKER_ID) private checker: InterestChecker,

--- a/src/view/telegram/triggers/MentionTrigger.ts
+++ b/src/view/telegram/triggers/MentionTrigger.ts
@@ -17,7 +17,7 @@ import type {
 } from '../../../domain/triggers/Trigger.interface';
 
 @injectable()
-export class MentionTrigger implements Trigger {
+export class MentionTrigger implements Trigger<Context> {
   private readonly logger: Logger;
   constructor(
     @inject(DIALOGUE_MANAGER_ID) private dialogue: DialogueManager,

--- a/src/view/telegram/triggers/NameTrigger.ts
+++ b/src/view/telegram/triggers/NameTrigger.ts
@@ -17,7 +17,7 @@ import type {
 } from '../../../domain/triggers/Trigger.interface';
 
 @injectable()
-export class NameTrigger implements Trigger {
+export class NameTrigger implements Trigger<Context> {
   private pattern: RegExp;
   private readonly logger: Logger;
   constructor(

--- a/src/view/telegram/triggers/ReplyTrigger.ts
+++ b/src/view/telegram/triggers/ReplyTrigger.ts
@@ -13,7 +13,7 @@ import type {
 } from '../../../domain/triggers/Trigger.interface';
 
 @injectable()
-export class ReplyTrigger implements Trigger {
+export class ReplyTrigger implements Trigger<Context> {
   private readonly logger: Logger;
   constructor(@inject(LOGGER_FACTORY_ID) loggerFactory: LoggerFactory) {
     this.logger = loggerFactory.create('ReplyTrigger');


### PR DESCRIPTION
## Summary
- make `Trigger` interface generic and adjust `TRIGGER_ID`
- bind typed triggers in the container and pipeline
- update Telegram triggers to implement `Trigger<Context>`

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a8542838a08327bea70ff497765c50