### PR TITLE
chore: add typescript import resolver

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -108,6 +108,7 @@ module.exports = [
         node: {
           extensions: ['.js', '.ts'],
         },
+        typescript: { project: './tsconfig.json' },
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.30.1",
     "eslint-config-prettier": "^10.1.5",
+    "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-unused-imports": "^4.1.4",


### PR DESCRIPTION
## Summary
- add eslint-import-resolver-typescript to dev dependencies
- configure ESLint to resolve TypeScript modules using project tsconfig

## Testing
- `npm run format:fix`
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a8691ec15483278bbaf7f21a03b942