### PR TITLE
Refactor repository tokens to plain symbols

### DIFF
--- a/src/domain/repositories/AccessKeyRepository.interface.ts
+++ b/src/domain/repositories/AccessKeyRepository.interface.ts
@@ -1,5 +1,3 @@
-import type { ServiceIdentifier } from 'inversify';
-
 import type { AccessKeyEntity } from '@/domain/entities/AccessKeyEntity';
 
 export interface AccessKeyRepository {
@@ -11,6 +9,4 @@ export interface AccessKeyRepository {
   deleteExpired(now: number): Promise<void>;
 }
 
-export const ACCESS_KEY_REPOSITORY_ID = Symbol.for(
-  'AccessKeyRepository'
-) as ServiceIdentifier<AccessKeyRepository>;
+export const ACCESS_KEY_REPOSITORY_ID = Symbol('AccessKeyRepository');

--- a/src/domain/repositories/ChatAccessRepository.interface.ts
+++ b/src/domain/repositories/ChatAccessRepository.interface.ts
@@ -1,5 +1,3 @@
-import type { ServiceIdentifier } from 'inversify';
-
 import type {
   ChatAccessEntity,
   ChatStatus,
@@ -12,6 +10,4 @@ export interface ChatAccessRepository {
   listAll(): Promise<ChatAccessEntity[]>;
 }
 
-export const CHAT_ACCESS_REPOSITORY_ID = Symbol.for(
-  'ChatAccessRepository'
-) as ServiceIdentifier<ChatAccessRepository>;
+export const CHAT_ACCESS_REPOSITORY_ID = Symbol('ChatAccessRepository');

--- a/src/domain/repositories/ChatConfigRepository.interface.ts
+++ b/src/domain/repositories/ChatConfigRepository.interface.ts
@@ -1,5 +1,3 @@
-import type { ServiceIdentifier } from 'inversify';
-
 import type { ChatConfigEntity } from '@/domain/entities/ChatConfigEntity';
 
 export interface ChatConfigRepository {
@@ -7,6 +5,4 @@ export interface ChatConfigRepository {
   findById(chatId: number): Promise<ChatConfigEntity | undefined>;
 }
 
-export const CHAT_CONFIG_REPOSITORY_ID = Symbol.for(
-  'ChatConfigRepository'
-) as ServiceIdentifier<ChatConfigRepository>;
+export const CHAT_CONFIG_REPOSITORY_ID = Symbol('ChatConfigRepository');

--- a/src/domain/repositories/ChatRepository.interface.ts
+++ b/src/domain/repositories/ChatRepository.interface.ts
@@ -1,5 +1,3 @@
-import type { ServiceIdentifier } from 'inversify';
-
 import type { ChatEntity } from '@/domain/entities/ChatEntity';
 
 export interface ChatRepository {
@@ -7,6 +5,4 @@ export interface ChatRepository {
   findById(chatId: number): Promise<ChatEntity | undefined>;
 }
 
-export const CHAT_REPOSITORY_ID = Symbol.for(
-  'ChatRepository'
-) as ServiceIdentifier<ChatRepository>;
+export const CHAT_REPOSITORY_ID = Symbol('ChatRepository');

--- a/src/domain/repositories/ChatUserRepository.interface.ts
+++ b/src/domain/repositories/ChatUserRepository.interface.ts
@@ -1,10 +1,6 @@
-import type { ServiceIdentifier } from 'inversify';
-
 export interface ChatUserRepository {
   link(chatId: number, userId: number): Promise<void>;
   listByChat(chatId: number): Promise<number[]>;
 }
 
-export const CHAT_USER_REPOSITORY_ID = Symbol.for(
-  'ChatUserRepository'
-) as ServiceIdentifier<ChatUserRepository>;
+export const CHAT_USER_REPOSITORY_ID = Symbol('ChatUserRepository');

--- a/src/domain/repositories/DbProvider.interface.ts
+++ b/src/domain/repositories/DbProvider.interface.ts
@@ -1,5 +1,3 @@
-import type { ServiceIdentifier } from 'inversify';
-
 export interface SqlDatabase {
   run(sql: string, ...params: unknown[]): Promise<unknown>;
   get<T>(sql: string, ...params: unknown[]): Promise<T | undefined>;
@@ -11,6 +9,4 @@ export interface DbProvider {
   listTables(): Promise<string[]>;
 }
 
-export const DB_PROVIDER_ID = Symbol.for(
-  'DbProvider'
-) as ServiceIdentifier<DbProvider>;
+export const DB_PROVIDER_ID = Symbol('DbProvider');

--- a/src/domain/repositories/MessageRepository.interface.ts
+++ b/src/domain/repositories/MessageRepository.interface.ts
@@ -1,5 +1,3 @@
-import type { ServiceIdentifier } from 'inversify';
-
 import type { ChatMessage } from '@/domain/messages/ChatMessage.interface';
 import type { StoredMessage } from '@/domain/messages/StoredMessage.interface';
 
@@ -11,6 +9,4 @@ export interface MessageRepository {
   clearByChatId(chatId: number): Promise<void>;
 }
 
-export const MESSAGE_REPOSITORY_ID = Symbol.for(
-  'MessageRepository'
-) as ServiceIdentifier<MessageRepository>;
+export const MESSAGE_REPOSITORY_ID = Symbol('MessageRepository');

--- a/src/domain/repositories/SummaryRepository.interface.ts
+++ b/src/domain/repositories/SummaryRepository.interface.ts
@@ -1,11 +1,7 @@
-import type { ServiceIdentifier } from 'inversify';
-
 export interface SummaryRepository {
   upsert(chatId: number, summary: string): Promise<void>;
   findById(chatId: number): Promise<string>;
   clearByChatId(chatId: number): Promise<void>;
 }
 
-export const SUMMARY_REPOSITORY_ID = Symbol.for(
-  'SummaryRepository'
-) as ServiceIdentifier<SummaryRepository>;
+export const SUMMARY_REPOSITORY_ID = Symbol('SummaryRepository');

--- a/src/domain/repositories/UserRepository.interface.ts
+++ b/src/domain/repositories/UserRepository.interface.ts
@@ -1,5 +1,3 @@
-import type { ServiceIdentifier } from 'inversify';
-
 import type { UserEntity } from '@/domain/entities/UserEntity';
 
 export interface UserRepository {
@@ -8,6 +6,4 @@ export interface UserRepository {
   setAttitude(userId: number, attitude: string): Promise<void>;
 }
 
-export const USER_REPOSITORY_ID = Symbol.for(
-  'UserRepository'
-) as ServiceIdentifier<UserRepository>;
+export const USER_REPOSITORY_ID = Symbol('UserRepository');


### PR DESCRIPTION
## Summary
- replace `ServiceIdentifier` imports in repository interfaces with plain `Symbol` exports
- keep container bindings using the updated symbol identifiers

## Testing
- `npm run format:fix`
- `npm run build`
- `npm run type:check`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a86fa028188327b055259222fa6ffe