### PR TITLE
Use nodemon for dev workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "rsbuild build",
     "start": "node dist/index.js",
-    "dev": "rsbuild dev",
+    "dev": "nodemon --watch src --ext ts --exec \"rsbuild build && node dist/index.js\"",
     "test": "vitest run --config vitest.config.ts",
     "test:watch": "vitest --config vitest.config.ts",
     "test:coverage": "vitest run --config vitest.config.ts --coverage",
@@ -54,6 +54,7 @@
     "eslint-plugin-unused-imports": "^4.1.4",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.2",
+    "nodemon": "^3.1.10",
     "prettier": "^3.6.2",
     "tsx": "^4.8.1",
     "typescript": "^5.8.3",


### PR DESCRIPTION
## Summary
- use nodemon for development reloads
- watch TypeScript sources and rebuild before running bot

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a87ef379608327a9e758e84dce7d8b