### PR TITLE
refactor: encapsulate chat and user invariants

### DIFF
--- a/src/application/use-cases/messages/RepositoryMessageService.ts
+++ b/src/application/use-cases/messages/RepositoryMessageService.ts
@@ -6,6 +6,8 @@ import {
   type LoggerFactory,
 } from '@/application/interfaces/logging/LoggerFactory.interface';
 import type { MessageService } from '@/application/interfaces/messages/MessageService.interface';
+import { ChatEntity } from '@/domain/entities/ChatEntity';
+import { UserEntity } from '@/domain/entities/UserEntity';
 import type { ChatMessage } from '@/domain/messages/ChatMessage.interface';
 import type { StoredMessage } from '@/domain/messages/StoredMessage.interface';
 import {
@@ -47,16 +49,15 @@ export class RepositoryMessageService implements MessageService {
       'Inserting message into database'
     );
     const storedUserId = message.userId ?? 0;
-    await this.chatRepo.upsert({
-      chatId: message.chatId,
-      title: message.chatTitle ?? null,
-    });
-    await this.userRepo.upsert({
-      id: storedUserId,
-      username: message.username ?? null,
-      firstName: message.firstName ?? null,
-      lastName: message.lastName ?? null,
-    });
+    const chat = new ChatEntity(message.chatId, message.chatTitle ?? null);
+    await this.chatRepo.upsert(chat);
+    const user = new UserEntity(
+      storedUserId,
+      message.username ?? null,
+      message.firstName ?? null,
+      message.lastName ?? null
+    );
+    await this.userRepo.upsert(user);
     await this.chatUserRepo.link(message.chatId, storedUserId);
     await this.messageRepo.insert({
       ...message,

--- a/src/domain/entities/ChatEntity.ts
+++ b/src/domain/entities/ChatEntity.ts
@@ -1,6 +1,21 @@
-/* c8 ignore start */
-export interface ChatEntity {
-  chatId: number;
-  title?: string | null;
+export class ChatEntity {
+  private _title: string | null;
+
+  constructor(
+    public readonly chatId: number,
+    title?: string | null
+  ) {
+    if (!Number.isInteger(chatId) || chatId <= 0) {
+      throw new Error('Invalid chat id');
+    }
+    this._title = title ?? null;
+  }
+
+  get title(): string | null {
+    return this._title;
+  }
+
+  rename(title?: string | null): void {
+    this._title = title ?? null;
+  }
 }
-/* c8 ignore end */

--- a/src/domain/entities/UserEntity.ts
+++ b/src/domain/entities/UserEntity.ts
@@ -1,9 +1,28 @@
-/* c8 ignore start */
-export interface UserEntity {
-  id: number;
-  username?: string | null;
-  firstName?: string | null;
-  lastName?: string | null;
-  attitude?: string | null;
+export class UserEntity {
+  private _attitude: string | null;
+
+  constructor(
+    public readonly id: number,
+    public username?: string | null,
+    public firstName?: string | null,
+    public lastName?: string | null,
+    attitude?: string | null
+  ) {
+    if (!Number.isInteger(id) || id < 0) {
+      throw new Error('Invalid user id');
+    }
+    this._attitude = attitude?.trim() ?? null;
+  }
+
+  get attitude(): string | null {
+    return this._attitude;
+  }
+
+  setAttitude(attitude: string): void {
+    const trimmed = attitude.trim();
+    if (trimmed === '') {
+      throw new Error('Attitude cannot be empty');
+    }
+    this._attitude = trimmed;
+  }
 }
-/* c8 ignore end */

--- a/src/domain/repositories/UserRepository.interface.ts
+++ b/src/domain/repositories/UserRepository.interface.ts
@@ -3,7 +3,6 @@ import type { UserEntity } from '@/domain/entities/UserEntity';
 export interface UserRepository {
   upsert(user: UserEntity): Promise<void>;
   findById(id: number): Promise<UserEntity | undefined>;
-  setAttitude(userId: number, attitude: string): Promise<void>;
 }
 
 export const USER_REPOSITORY_ID = Symbol('UserRepository');

--- a/src/infrastructure/persistence/sqlite/SQLiteChatRepository.ts
+++ b/src/infrastructure/persistence/sqlite/SQLiteChatRepository.ts
@@ -1,6 +1,6 @@
 import { inject, injectable } from 'inversify';
 
-import type { ChatEntity } from '@/domain/entities/ChatEntity';
+import { ChatEntity } from '@/domain/entities/ChatEntity';
 import type { ChatRepository } from '@/domain/repositories/ChatRepository.interface';
 import {
   DB_PROVIDER_ID,
@@ -27,6 +27,6 @@ export class SQLiteChatRepository implements ChatRepository {
       'SELECT chat_id, title FROM chats WHERE chat_id = ?',
       chatId
     );
-    return row ? { chatId: row.chat_id, title: row.title } : undefined;
+    return row ? new ChatEntity(row.chat_id, row.title) : undefined;
   }
 }

--- a/test/AdminServiceImpl.test.ts
+++ b/test/AdminServiceImpl.test.ts
@@ -9,6 +9,7 @@ import type { ChatUserRepository } from '../src/domain/repositories/ChatUserRepo
 import type { MessageRepository } from '../src/domain/repositories/MessageRepository.interface';
 import type { SummaryRepository } from '../src/domain/repositories/SummaryRepository.interface';
 import type { UserRepository } from '../src/domain/repositories/UserRepository.interface';
+import { UserEntity } from '../src/domain/entities/UserEntity';
 import { AdminServiceImpl } from '../src/application/use-cases/admin/AdminServiceImpl';
 import type { ChatConfigService } from '../src/application/interfaces/chat/ChatConfigService.interface';
 import type { LoggerFactory } from '../src/application/interfaces/logging/LoggerFactory.interface';
@@ -124,13 +125,7 @@ describe('AdminServiceImpl', () => {
     const summaryRepo = { findById: vi.fn(async () => 's') };
     const chatUserRepo = { listByChat: vi.fn(async () => [1]) };
     const userRepo = {
-      findById: vi.fn(async () => ({
-        id: 1,
-        username: 'u',
-        firstName: 'F',
-        lastName: 'L',
-        attitude: null,
-      })),
+      findById: vi.fn(async () => new UserEntity(1, 'u', 'F', 'L', null)),
     };
     const admin = new AdminServiceImpl(
       { get: vi.fn(), listTables: vi.fn() } as unknown as DbProvider,


### PR DESCRIPTION
## Summary
- introduce ChatEntity and UserEntity classes with validation logic
- update repositories and services to use new entity methods
- migrate attitude handling into UserEntity and adjust tests

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a880bc3ad08327ad8c4a48932597b5