### PR TITLE
Externalize sqlite3 bindings for development

### DIFF
--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
     rspack: {
       target: 'node',
       externalsPresets: { node: true },
+      externals: {
+        sqlite3: 'commonjs sqlite3',
+      },
     },
     swc: {
       jsc: {


### PR DESCRIPTION
## Summary
- externalize `sqlite3` in rsbuild so native bindings load correctly

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a8c06c16248327b400d650ce577aa2