### PR TITLE
Add RabbitMQ priority queue service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,6 @@ DATABASE_URL=file:///data/memory.db
 LOG_LEVEL=debug
 ADMIN_CHAT_ID=***
 LOG_PROMPTS=false
+RABBITMQ_URL=amqp://localhost
+RABBITMQ_QUEUE=bot-queue
+RABBITMQ_MAX_PRIORITY=10

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "amqplib": "^0.10.8",
     "dotenv": "^17.1.0",
     "inversify": "^7.0.0-alpha.5",
     "openai": "^5.12.2",
@@ -37,6 +38,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
+    "@types/amqplib": "^0.10.7",
     "@rsbuild/core": "^1.4.15",
     "@rspack/core": "^1.4.11",
     "@types/node": "^24.0.11",

--- a/src/application/interfaces/env/EnvService.ts
+++ b/src/application/interfaces/env/EnvService.ts
@@ -9,6 +9,9 @@ export interface Env {
   ADMIN_CHAT_ID: number;
   NODE_ENV: string;
   LOG_PROMPTS: boolean;
+  RABBITMQ_URL: string;
+  RABBITMQ_QUEUE: string;
+  RABBITMQ_MAX_PRIORITY: number;
 }
 
 export interface EnvService {

--- a/src/application/interfaces/queue/RabbitMQService.ts
+++ b/src/application/interfaces/queue/RabbitMQService.ts
@@ -1,0 +1,12 @@
+import type { ServiceIdentifier } from 'inversify';
+
+export interface RabbitMQService {
+  publish(message: string, priority: number): Promise<void>;
+  consume(
+    onMessage: (message: string, priority: number) => Promise<void>
+  ): Promise<void>;
+}
+
+export const RABBITMQ_SERVICE_ID = Symbol.for(
+  'RabbitMQService'
+) as ServiceIdentifier<RabbitMQService>;

--- a/src/container/application.ts
+++ b/src/container/application.ts
@@ -73,6 +73,10 @@ import {
   type PromptService,
 } from '../application/interfaces/prompts/PromptService';
 import {
+  RABBITMQ_SERVICE_ID,
+  type RabbitMQService,
+} from '../application/interfaces/queue/RabbitMQService';
+import {
   SUMMARY_SERVICE_ID,
   type SummaryService,
 } from '../application/interfaces/summaries/SummaryService';
@@ -96,6 +100,7 @@ import { TestEnvService } from '../infrastructure/config/TestEnvService';
 import { ChatGPTService } from '../infrastructure/external/ChatGPTService';
 import { FilePromptService } from '../infrastructure/external/FilePromptService';
 import { PinoLoggerFactory } from '../infrastructure/logging/PinoLoggerFactory';
+import { AmqplibRabbitMQService } from '../infrastructure/queue/RabbitMQService';
 
 export const register = (container: Container): void => {
   const EnvServiceImpl =
@@ -114,6 +119,11 @@ export const register = (container: Container): void => {
   container
     .bind<PromptService>(PROMPT_SERVICE_ID)
     .to(FilePromptService)
+    .inSingletonScope();
+
+  container
+    .bind<RabbitMQService>(RABBITMQ_SERVICE_ID)
+    .to(AmqplibRabbitMQService)
     .inSingletonScope();
 
   container

--- a/src/infrastructure/config/TestEnvService.ts
+++ b/src/infrastructure/config/TestEnvService.ts
@@ -18,6 +18,9 @@ export class TestEnvService implements EnvService {
       ADMIN_CHAT_ID: process.env.ADMIN_CHAT_ID ?? '0',
       NODE_ENV: 'test',
       LOG_PROMPTS: process.env.LOG_PROMPTS ?? false,
+      RABBITMQ_URL: process.env.RABBITMQ_URL ?? 'amqp://localhost',
+      RABBITMQ_QUEUE: process.env.RABBITMQ_QUEUE ?? 'test-queue',
+      RABBITMQ_MAX_PRIORITY: process.env.RABBITMQ_MAX_PRIORITY ?? '10',
     });
   }
 

--- a/src/infrastructure/config/envSchema.ts
+++ b/src/infrastructure/config/envSchema.ts
@@ -10,4 +10,7 @@ export const envSchema = z.object({
   ADMIN_CHAT_ID: z.coerce.number(),
   NODE_ENV: z.string().default('development'),
   LOG_PROMPTS: z.coerce.boolean().default(false),
+  RABBITMQ_URL: z.string().min(1),
+  RABBITMQ_QUEUE: z.string().min(1),
+  RABBITMQ_MAX_PRIORITY: z.coerce.number(),
 }) as z.ZodType<Env>;

--- a/src/infrastructure/queue/RabbitMQService.ts
+++ b/src/infrastructure/queue/RabbitMQService.ts
@@ -1,0 +1,55 @@
+import amqp, { type Channel, type ConsumeMessage } from 'amqplib';
+import { inject, injectable } from 'inversify';
+
+import {
+  ENV_SERVICE_ID,
+  type EnvService,
+} from '@/application/interfaces/env/EnvService';
+import type { RabbitMQService } from '@/application/interfaces/queue/RabbitMQService';
+
+@injectable()
+export class AmqplibRabbitMQService implements RabbitMQService {
+  private channel?: Channel;
+
+  constructor(
+    @inject(ENV_SERVICE_ID) private readonly envService: EnvService
+  ) {}
+
+  async publish(message: string, priority: number): Promise<void> {
+    const channel = await this.getChannel();
+    channel.sendToQueue(
+      this.envService.env.RABBITMQ_QUEUE,
+      Buffer.from(message),
+      { priority }
+    );
+  }
+
+  async consume(
+    onMessage: (message: string, priority: number) => Promise<void>
+  ): Promise<void> {
+    const channel = await this.getChannel();
+    await channel.consume(
+      this.envService.env.RABBITMQ_QUEUE,
+      async (msg: ConsumeMessage | null) => {
+        if (!msg) {
+          return;
+        }
+        await onMessage(msg.content.toString(), msg.properties.priority ?? 0);
+        channel.ack(msg);
+      }
+    );
+  }
+
+  private async getChannel(): Promise<Channel> {
+    if (!this.channel) {
+      const connection = await amqp.connect(this.envService.env.RABBITMQ_URL);
+      const channel = await connection.createChannel();
+      await channel.assertQueue(this.envService.env.RABBITMQ_QUEUE, {
+        durable: true,
+        maxPriority: this.envService.env.RABBITMQ_MAX_PRIORITY,
+      });
+      this.channel = channel;
+    }
+    return this.channel as Channel;
+  }
+}


### PR DESCRIPTION
## Summary
- install amqplib and its types
- expose RabbitMQ configuration and interface
- implement and bind RabbitMQ priority queue service

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a8f12d97408327a91e2977530a7827