### PR TITLE
Show admin menu for admin chat

### DIFF
--- a/src/view/telegram/TelegramBot.ts
+++ b/src/view/telegram/TelegramBot.ts
@@ -353,6 +353,11 @@ export class TelegramBot {
     const chatId = ctx.chat?.id;
     const userId = ctx.from?.id;
     assert(chatId, 'This is not a chat');
+    if (chatId === this.env.ADMIN_CHAT_ID) {
+      this.logger.info({ chatId, userId }, 'Showing admin menu');
+      await this.router.show(ctx, 'admin_menu');
+      return;
+    }
     this.logger.info({ chatId, userId }, 'Showing user menu');
     await this.router.show(ctx, 'menu');
   }

--- a/test/TelegramBot.test.ts
+++ b/test/TelegramBot.test.ts
@@ -1229,7 +1229,7 @@ describe('TelegramBot', () => {
     botWithRouter.router = { show: vi.fn() };
     const ctx = { chat: { id: 1 } } as unknown as Context;
     await botWithRouter.showMenu(ctx);
-    expect(botWithRouter.router.show).toHaveBeenCalledWith(ctx, 'menu');
+    expect(botWithRouter.router.show).toHaveBeenCalledWith(ctx, 'admin_menu');
   });
 
   it('shows menu regardless of chat status', async () => {


### PR DESCRIPTION
## Summary
- show admin menu when command from admin chat
- test admin chat routing to admin menu

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68adcfbe2fa08327aea965c9ff761e4f