### PR TITLE
Check chat status before showing menu

### DIFF
--- a/src/view/telegram/TelegramBot.ts
+++ b/src/view/telegram/TelegramBot.ts
@@ -358,6 +358,8 @@ export class TelegramBot {
       await this.router.show(ctx, 'admin_menu');
       return;
     }
+    const allowed = await this.checkChatStatus(ctx, chatId);
+    if (!allowed) return;
     this.logger.info({ chatId, userId }, 'Showing user menu');
     await this.router.show(ctx, 'menu');
   }
@@ -635,11 +637,10 @@ export class TelegramBot {
     chatId: number
   ): Promise<boolean> {
     const status = await this.approvalService.getStatus(chatId);
-    if (status === 'banned') {
-      this.logger.warn({ chatId }, 'Message from banned chat ignored');
-      return false;
-    }
     if (status !== 'approved') {
+      if (status === 'banned') {
+        this.logger.warn({ chatId }, 'Message from banned chat ignored');
+      }
       await this.router.show(ctx, 'chat_not_approved');
       return false;
     }


### PR DESCRIPTION
## Summary
- ensure user menu is shown only after chat status is approved
- display not-approved window for banned or pending chats
- update tests for unapproved chat scenarios

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68add1733b8c8327b4f6fbaa0ef26fcf