### PR TITLE
feat: add prompt template service

### DIFF
--- a/src/application/interfaces/prompts/PromptTemplateService.ts
+++ b/src/application/interfaces/prompts/PromptTemplateService.ts
@@ -1,0 +1,20 @@
+export interface PromptTemplateService {
+  getPersonaTemplate(): Promise<string>;
+  getUsersTemplate(): Promise<string>;
+  getRestrictionsTemplate(): Promise<string>;
+  getAskSummaryTemplate(): Promise<string>;
+  getSummarizationSystemTemplate(): Promise<string>;
+  getPreviousSummaryTemplate(): Promise<string>;
+  getInterestCheckTemplate(): Promise<string>;
+  getUserPromptTemplate(): Promise<string>;
+  getUserPromptSystemTemplate(): Promise<string>;
+  getPriorityRulesSystemTemplate(): Promise<string>;
+  getAssessUsersTemplate(): Promise<string>;
+  getReplyTriggerTemplate(): Promise<string>;
+}
+
+import type { ServiceIdentifier } from 'inversify';
+
+export const PROMPT_TEMPLATE_SERVICE_ID = Symbol.for(
+  'PromptTemplateService'
+) as ServiceIdentifier<PromptTemplateService>;

--- a/src/container/application.ts
+++ b/src/container/application.ts
@@ -77,6 +77,10 @@ import {
   type PromptService,
 } from '../application/interfaces/prompts/PromptService';
 import {
+  PROMPT_TEMPLATE_SERVICE_ID,
+  type PromptTemplateService,
+} from '../application/interfaces/prompts/PromptTemplateService';
+import {
   RABBITMQ_SERVICE_ID,
   type RabbitMQService,
 } from '../application/interfaces/queue/RabbitMQService';
@@ -105,6 +109,7 @@ import { ChatGPTService } from '../infrastructure/external/ChatGPTService';
 import { FilePromptService } from '../infrastructure/external/FilePromptService';
 import { OpenAIClientService } from '../infrastructure/external/OpenAIClient';
 import { PinoLoggerFactory } from '../infrastructure/logging/PinoLoggerFactory';
+import { FilePromptTemplateService } from '../infrastructure/prompts/FilePromptTemplateService';
 import { AmqplibRabbitMQService } from '../infrastructure/queue/RabbitMQService';
 
 export const register = (container: Container): void => {
@@ -119,6 +124,11 @@ export const register = (container: Container): void => {
   container
     .bind<LoggerFactory>(LOGGER_FACTORY_ID)
     .to(PinoLoggerFactory)
+    .inSingletonScope();
+
+  container
+    .bind<PromptTemplateService>(PROMPT_TEMPLATE_SERVICE_ID)
+    .to(FilePromptTemplateService)
     .inSingletonScope();
 
   container

--- a/src/infrastructure/prompts/FilePromptTemplateService.ts
+++ b/src/infrastructure/prompts/FilePromptTemplateService.ts
@@ -1,0 +1,130 @@
+import { readFile } from 'fs/promises';
+import { inject, injectable } from 'inversify';
+
+import type { EnvService } from '@/application/interfaces/env/EnvService';
+import { ENV_SERVICE_ID } from '@/application/interfaces/env/EnvService';
+import type { Logger } from '@/application/interfaces/logging/Logger';
+import {
+  LOGGER_FACTORY_ID,
+  type LoggerFactory,
+} from '@/application/interfaces/logging/LoggerFactory';
+import type { PromptTemplateService } from '@/application/interfaces/prompts/PromptTemplateService';
+import { createLazy } from '@/utils/lazy';
+
+@injectable()
+export class FilePromptTemplateService implements PromptTemplateService {
+  private readonly persona: () => Promise<string>;
+  private readonly users: () => Promise<string>;
+  private readonly restrictions: () => Promise<string>;
+  private readonly askSummary: () => Promise<string>;
+  private readonly summarizationSystem: () => Promise<string>;
+  private readonly previousSummary: () => Promise<string>;
+  private readonly checkInterest: () => Promise<string>;
+  private readonly userPrompt: () => Promise<string>;
+  private readonly userPromptSystem: () => Promise<string>;
+  private readonly priorityRulesSystem: () => Promise<string>;
+  private readonly assessUsers: () => Promise<string>;
+  private readonly replyTrigger: () => Promise<string>;
+  private readonly logger: Logger;
+
+  constructor(
+    @inject(ENV_SERVICE_ID) envService: EnvService,
+    @inject(LOGGER_FACTORY_ID) loggerFactory: LoggerFactory
+  ) {
+    const files = envService.getPromptFiles();
+    this.logger = loggerFactory.create('FilePromptTemplateService');
+    this.persona = createLazy(() =>
+      this.loadTemplate('persona', files.persona)
+    );
+    // These templates may not have separate files; reuse existing ones if needed
+    this.users = createLazy(() =>
+      this.loadTemplate('users', files.assessUsers)
+    );
+    this.restrictions = createLazy(() =>
+      this.loadTemplate('restrictions', files.priorityRulesSystem)
+    );
+    this.askSummary = createLazy(() =>
+      this.loadTemplate('askSummary', files.askSummary)
+    );
+    this.summarizationSystem = createLazy(() =>
+      this.loadTemplate('summarizationSystem', files.summarizationSystem)
+    );
+    this.previousSummary = createLazy(() =>
+      this.loadTemplate('previousSummary', files.previousSummary)
+    );
+    this.checkInterest = createLazy(() =>
+      this.loadTemplate('checkInterest', files.checkInterest)
+    );
+    this.userPrompt = createLazy(() =>
+      this.loadTemplate('userPrompt', files.userPrompt)
+    );
+    this.userPromptSystem = createLazy(() =>
+      this.loadTemplate('userPromptSystem', files.userPromptSystem)
+    );
+    this.priorityRulesSystem = createLazy(() =>
+      this.loadTemplate('priorityRulesSystem', files.priorityRulesSystem)
+    );
+    this.assessUsers = createLazy(() =>
+      this.loadTemplate('assessUsers', files.assessUsers)
+    );
+    this.replyTrigger = createLazy(() =>
+      this.loadTemplate('replyTrigger', files.replyTrigger)
+    );
+  }
+
+  async getPersonaTemplate(): Promise<string> {
+    return this.persona();
+  }
+
+  async getUsersTemplate(): Promise<string> {
+    return this.users();
+  }
+
+  async getRestrictionsTemplate(): Promise<string> {
+    return this.restrictions();
+  }
+
+  async getAskSummaryTemplate(): Promise<string> {
+    return this.askSummary();
+  }
+
+  async getSummarizationSystemTemplate(): Promise<string> {
+    return this.summarizationSystem();
+  }
+
+  async getPreviousSummaryTemplate(): Promise<string> {
+    return this.previousSummary();
+  }
+
+  async getInterestCheckTemplate(): Promise<string> {
+    return this.checkInterest();
+  }
+
+  async getUserPromptTemplate(): Promise<string> {
+    return this.userPrompt();
+  }
+
+  async getUserPromptSystemTemplate(): Promise<string> {
+    return this.userPromptSystem();
+  }
+
+  async getPriorityRulesSystemTemplate(): Promise<string> {
+    return this.priorityRulesSystem();
+  }
+
+  async getAssessUsersTemplate(): Promise<string> {
+    return this.assessUsers();
+  }
+
+  async getReplyTriggerTemplate(): Promise<string> {
+    return this.replyTrigger();
+  }
+
+  private async loadTemplate(name: string, path: string): Promise<string> {
+    const content = await readFile(path, 'utf-8');
+    this.logger.debug(
+      `Loaded ${name} template from ${path} (${Buffer.byteLength(content)} bytes)`
+    );
+    return content;
+  }
+}

--- a/test/PromptService.test.ts
+++ b/test/PromptService.test.ts
@@ -86,6 +86,9 @@ describe('FilePromptService', () => {
     readFileSpy = vi.fn(actual.readFile);
     vi.doMock('fs/promises', () => ({ ...actual, readFile: readFileSpy }));
 
+    const { FilePromptTemplateService } = await import(
+      '../src/infrastructure/prompts/FilePromptTemplateService'
+    );
     const { FilePromptService } = await import(
       '../src/infrastructure/external/FilePromptService'
     );
@@ -99,7 +102,8 @@ describe('FilePromptService', () => {
         child: vi.fn(),
       }),
     } as unknown as LoggerFactory;
-    service = new FilePromptService(env, loggerFactory);
+    const templateService = new FilePromptTemplateService(env, loggerFactory);
+    service = new FilePromptService(templateService);
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- add `PromptTemplateService` interface for accessing prompt templates
- implement file-based template loading and refactor `FilePromptService`
- register template service in DI container and update tests

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68adf5e878588327bcaa4f84e65c71a8