### PR TITLE
Refactor prompt loading via template service

### DIFF
--- a/src/application/interfaces/prompts/PromptTemplateService.ts
+++ b/src/application/interfaces/prompts/PromptTemplateService.ts
@@ -1,0 +1,9 @@
+export interface PromptTemplateService {
+  loadTemplate(name: string): Promise<string>;
+}
+
+import type { ServiceIdentifier } from 'inversify';
+
+export const PROMPT_TEMPLATE_SERVICE_ID = Symbol.for(
+  'PromptTemplateService'
+) as ServiceIdentifier<PromptTemplateService>;

--- a/src/container/application.ts
+++ b/src/container/application.ts
@@ -73,6 +73,10 @@ import {
   type PromptService,
 } from '../application/interfaces/prompts/PromptService';
 import {
+  PROMPT_TEMPLATE_SERVICE_ID,
+  type PromptTemplateService,
+} from '../application/interfaces/prompts/PromptTemplateService';
+import {
   SUMMARY_SERVICE_ID,
   type SummaryService,
 } from '../application/interfaces/summaries/SummaryService';
@@ -95,6 +99,7 @@ import { DefaultEnvService } from '../infrastructure/config/DefaultEnvService';
 import { TestEnvService } from '../infrastructure/config/TestEnvService';
 import { ChatGPTService } from '../infrastructure/external/ChatGPTService';
 import { FilePromptService } from '../infrastructure/external/FilePromptService';
+import { FilePromptTemplateService } from '../infrastructure/external/FilePromptTemplateService';
 import { PinoLoggerFactory } from '../infrastructure/logging/PinoLoggerFactory';
 
 export const register = (container: Container): void => {
@@ -109,6 +114,11 @@ export const register = (container: Container): void => {
   container
     .bind<LoggerFactory>(LOGGER_FACTORY_ID)
     .to(PinoLoggerFactory)
+    .inSingletonScope();
+
+  container
+    .bind<PromptTemplateService>(PROMPT_TEMPLATE_SERVICE_ID)
+    .to(FilePromptTemplateService)
     .inSingletonScope();
 
   container

--- a/src/infrastructure/external/FilePromptTemplateService.ts
+++ b/src/infrastructure/external/FilePromptTemplateService.ts
@@ -1,0 +1,44 @@
+import { readFile } from 'fs/promises';
+import { inject, injectable } from 'inversify';
+
+import type { EnvService } from '@/application/interfaces/env/EnvService';
+import { ENV_SERVICE_ID } from '@/application/interfaces/env/EnvService';
+import type { Logger } from '@/application/interfaces/logging/Logger';
+import {
+  LOGGER_FACTORY_ID,
+  type LoggerFactory,
+} from '@/application/interfaces/logging/LoggerFactory';
+import type { PromptTemplateService } from '@/application/interfaces/prompts/PromptTemplateService';
+
+@injectable()
+export class FilePromptTemplateService implements PromptTemplateService {
+  private readonly files: Record<string, string>;
+  private readonly cache = new Map<string, Promise<string>>();
+  private readonly logger: Logger;
+
+  constructor(
+    @inject(ENV_SERVICE_ID) envService: EnvService,
+    @inject(LOGGER_FACTORY_ID) loggerFactory: LoggerFactory
+  ) {
+    this.files = envService.getPromptFiles();
+    this.logger = loggerFactory.create('FilePromptTemplateService');
+  }
+
+  async loadTemplate(name: string): Promise<string> {
+    let template = this.cache.get(name);
+    if (!template) {
+      const path = this.files[name as keyof typeof this.files];
+      if (!path) {
+        throw new Error(`Unknown prompt template: ${name}`);
+      }
+      template = readFile(path, 'utf-8').then((content) => {
+        this.logger.debug(
+          `Loaded ${name} template from ${path} (${Buffer.byteLength(content)} bytes)`
+        );
+        return content;
+      });
+      this.cache.set(name, template);
+    }
+    return template;
+  }
+}

--- a/test/PromptService.test.ts
+++ b/test/PromptService.test.ts
@@ -97,6 +97,9 @@ describe('FilePromptService', () => {
     const { FilePromptService } = await import(
       '../src/infrastructure/external/FilePromptService'
     );
+    const { FilePromptTemplateService } = await import(
+      '../src/infrastructure/external/FilePromptTemplateService'
+    );
     const env = new TempEnvService(dir);
     const loggerFactory: LoggerFactory = {
       create: () => ({
@@ -107,7 +110,8 @@ describe('FilePromptService', () => {
         child: vi.fn(),
       }),
     } as unknown as LoggerFactory;
-    service = new FilePromptService(env, loggerFactory);
+    const templateService = new FilePromptTemplateService(env, loggerFactory);
+    service = new FilePromptService(templateService);
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- add PromptTemplateService interface for loading prompt templates
- implement FilePromptTemplateService to read templates from EnvService file paths
- refactor FilePromptService to use new template service and register it in IoC container

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68adffbac4448327a1a83adaea800b42