### PR TITLE
Add tests for prompt components with Vitest mocks

### DIFF
--- a/test/PromptDirector.test.ts
+++ b/test/PromptDirector.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { PromptDirector } from '../src/application/prompts/PromptDirector';
 import type {
@@ -8,76 +8,70 @@ import type {
 import type { ChatMessage } from '../src/domain/messages/ChatMessage';
 import type { TriggerReason } from '../src/domain/triggers/Trigger';
 
-class FakeBuilder {
-  private steps: string[] = [];
-  addPersona(): this {
-    this.steps.push('persona');
-    return this;
-  }
-  addPriorityRulesSystem(): this {
-    this.steps.push('rules');
-    return this;
-  }
-  addUserPromptSystem(): this {
-    this.steps.push('userPromptSystem');
-    return this;
-  }
-  addCheckInterest(): this {
-    this.steps.push('checkInterest');
-    return this;
-  }
-  addAskSummary(summary?: string): this {
-    if (summary) {
-      this.steps.push(`askSummary:${summary}`);
-    }
-    return this;
-  }
-  addReplyTrigger(reason?: string, message?: string): this {
-    if (reason && message) {
-      this.steps.push(`trigger:${reason}:${message}`);
-    }
-    return this;
-  }
-  addChatUsers(
-    users: { username: string; fullName: string; attitude: string }[]
-  ): this {
-    this.steps.push(`chatUsers:${users.map((u) => u.username).join(',')}`);
-    return this;
-  }
-  addUserPrompt(params: { userMessage: string }): this {
-    this.steps.push(`user:${params.userMessage}`);
-    return this;
-  }
-  addMessages(messages: ChatMessage[]): this {
-    for (const m of messages) {
-      this.addUserPrompt({ userMessage: m.content });
-    }
-    return this;
-  }
-  addSummarizationSystem(): this {
-    this.steps.push('summarySystem');
-    return this;
-  }
-  addPreviousSummary(summary?: string): this {
-    if (summary) {
-      this.steps.push(`prev:${summary}`);
-    }
-    return this;
-  }
-  addAssessUsers(): this {
-    this.steps.push('assessUsers');
-    return this;
-  }
-  build(): Promise<string> {
-    return Promise.resolve(this.steps.join('|'));
-  }
+function createBuilder() {
+  const calls: string[] = [];
+  const builder = {
+    calls,
+    addPersona: vi.fn(() => {
+      calls.push('addPersona');
+      return builder;
+    }),
+    addPriorityRulesSystem: vi.fn(() => {
+      calls.push('addPriorityRulesSystem');
+      return builder;
+    }),
+    addUserPromptSystem: vi.fn(() => {
+      calls.push('addUserPromptSystem');
+      return builder;
+    }),
+    addAskSummary: vi.fn((summary?: string) => {
+      calls.push('addAskSummary');
+      return builder;
+    }),
+    addReplyTrigger: vi.fn((why?: string, message?: string) => {
+      calls.push('addReplyTrigger');
+      return builder;
+    }),
+    addChatUsers: vi.fn((users: unknown) => {
+      calls.push('addChatUsers');
+      return builder;
+    }),
+    addUserPrompt: vi.fn(() => {
+      calls.push('addUserPrompt');
+      return builder;
+    }),
+    addMessages: vi.fn((messages: unknown) => {
+      calls.push('addMessages');
+      return builder;
+    }),
+    addSummarizationSystem: vi.fn(() => {
+      calls.push('addSummarizationSystem');
+      return builder;
+    }),
+    addPreviousSummary: vi.fn((summary?: string) => {
+      calls.push('addPreviousSummary');
+      return builder;
+    }),
+    addCheckInterest: vi.fn(() => {
+      calls.push('addCheckInterest');
+      return builder;
+    }),
+    addAssessUsers: vi.fn(() => {
+      calls.push('addAssessUsers');
+      return builder;
+    }),
+    build: vi.fn(async () => {
+      calls.push('build');
+      return 'result';
+    }),
+  };
+  return builder as unknown as PromptBuilder & { calls: string[] };
 }
 
 describe('PromptDirector', () => {
-  const factory: PromptBuilderFactory = () =>
-    new FakeBuilder() as unknown as PromptBuilder;
-
   it('creates answer prompt', async () => {
+    const builder = createBuilder();
+    const factory: PromptBuilderFactory = () => builder;
     const director = new PromptDirector(factory);
     const history: ChatMessage[] = [
       {
@@ -85,18 +79,35 @@ describe('PromptDirector', () => {
         content: 'hi',
         username: 'u1',
         attitude: 'a1',
+        fullName: 'F1',
         messageId: 1,
       },
       { role: 'assistant', content: 'hello' },
     ];
     const trigger: TriggerReason = { why: 'w', message: 'm' };
-    const result = await director.createAnswerPrompt(history, 'sum', trigger);
-    expect(result).toBe(
-      'persona|rules|userPromptSystem|askSummary:sum|trigger:w:m|chatUsers:u1|user:hi|user:hello'
-    );
+    await director.createAnswerPrompt(history, 'sum', trigger);
+
+    expect(builder.calls).toEqual([
+      'addPersona',
+      'addPriorityRulesSystem',
+      'addUserPromptSystem',
+      'addAskSummary',
+      'addReplyTrigger',
+      'addChatUsers',
+      'addMessages',
+      'build',
+    ]);
+    expect(builder.addAskSummary).toHaveBeenCalledWith('sum');
+    expect(builder.addReplyTrigger).toHaveBeenCalledWith('w', 'm');
+    expect(builder.addChatUsers).toHaveBeenCalledWith([
+      { username: 'u1', fullName: 'F1', attitude: 'a1' },
+    ]);
+    expect(builder.addMessages).toHaveBeenCalledWith(history);
   });
 
   it('creates summary prompt', async () => {
+    const builder = createBuilder();
+    const factory: PromptBuilderFactory = () => builder;
     const director = new PromptDirector(factory);
     const history: ChatMessage[] = [
       {
@@ -104,15 +115,26 @@ describe('PromptDirector', () => {
         content: 'hi',
         username: 'u1',
         attitude: 'a1',
+        fullName: 'F1',
         messageId: 1,
       },
       { role: 'assistant', content: 'hello' },
     ];
-    const result = await director.createSummaryPrompt(history, 'prev');
-    expect(result).toBe('summarySystem|prev:prev|user:hi|user:hello');
+    await director.createSummaryPrompt(history, 'prev');
+
+    expect(builder.calls).toEqual([
+      'addSummarizationSystem',
+      'addPreviousSummary',
+      'addMessages',
+      'build',
+    ]);
+    expect(builder.addPreviousSummary).toHaveBeenCalledWith('prev');
+    expect(builder.addMessages).toHaveBeenCalledWith(history);
   });
 
   it('creates interest prompt', async () => {
+    const builder = createBuilder();
+    const factory: PromptBuilderFactory = () => builder;
     const director = new PromptDirector(factory);
     const history: ChatMessage[] = [
       {
@@ -120,15 +142,25 @@ describe('PromptDirector', () => {
         content: 'hi',
         username: 'u1',
         attitude: 'a1',
+        fullName: 'F1',
         messageId: 1,
       },
       { role: 'assistant', content: 'hello' },
     ];
-    const result = await director.createInterestPrompt(history);
-    expect(result).toBe('persona|checkInterest|user:hi|user:hello');
+    await director.createInterestPrompt(history);
+
+    expect(builder.calls).toEqual([
+      'addPersona',
+      'addCheckInterest',
+      'addMessages',
+      'build',
+    ]);
+    expect(builder.addMessages).toHaveBeenCalledWith(history);
   });
 
   it('creates assess users prompt', async () => {
+    const builder = createBuilder();
+    const factory: PromptBuilderFactory = () => builder;
     const director = new PromptDirector(factory);
     const history: ChatMessage[] = [
       {
@@ -136,13 +168,23 @@ describe('PromptDirector', () => {
         content: 'hi',
         username: 'u1',
         attitude: 'a1',
-        messageId: 1,
         fullName: 'F1',
+        messageId: 1,
       },
       { role: 'assistant', content: 'hello' },
     ];
     const prev = [{ username: 'u1', attitude: 'old' }];
-    const result = await director.createAssessUsersPrompt(history, prev);
-    expect(result).toBe('persona|assessUsers|chatUsers:u1|user:hi|user:hello');
+    await director.createAssessUsersPrompt(history, prev);
+
+    expect(builder.calls).toEqual([
+      'addPersona',
+      'addAssessUsers',
+      'addChatUsers',
+      'addMessages',
+      'build',
+    ]);
+    expect(builder.addChatUsers).toHaveBeenCalledWith([
+      { username: 'u1', fullName: 'F1', attitude: 'old' },
+    ]);
   });
 });

--- a/test/PromptTemplateService.test.ts
+++ b/test/PromptTemplateService.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(),
+}));
+
+import { readFile } from 'fs/promises';
+
+import type {
+  EnvService,
+  PromptFiles,
+} from '../src/application/interfaces/env/EnvService';
+import type { LoggerFactory } from '../src/application/interfaces/logging/LoggerFactory';
+import { FilePromptTemplateService } from '../src/infrastructure/external/FilePromptTemplateService';
+
+describe('FilePromptTemplateService', () => {
+  let service: FilePromptTemplateService;
+
+  beforeEach(() => {
+    const files: PromptFiles = {
+      persona: '/persona.md',
+      askSummary: '',
+      summarizationSystem: '',
+      previousSummary: '',
+      checkInterest: '',
+      userPrompt: '',
+      userPromptSystem: '',
+      chatUser: '',
+      priorityRulesSystem: '',
+      assessUsers: '',
+      replyTrigger: '',
+    };
+    const env: EnvService = {
+      env: {} as any,
+      getModels: vi.fn() as any,
+      getPromptFiles: () => files,
+      getBotName: vi.fn() as any,
+      getDialogueTimeoutMs: vi.fn() as any,
+      getMigrationsDir: vi.fn() as any,
+    } as unknown as EnvService;
+    const loggerFactory: LoggerFactory = {
+      create: () => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        child: vi.fn(),
+      }),
+    } as unknown as LoggerFactory;
+    service = new FilePromptTemplateService(env, loggerFactory);
+    vi.mocked(readFile).mockClear();
+  });
+
+  it('reads template from file and caches result', async () => {
+    vi.mocked(readFile).mockResolvedValue('hello');
+
+    await expect(service.loadTemplate('persona')).resolves.toBe('hello');
+    await expect(service.loadTemplate('persona')).resolves.toBe('hello');
+
+    expect(readFile).toHaveBeenCalledTimes(1);
+    expect(readFile).toHaveBeenCalledWith('/persona.md', 'utf-8');
+  });
+});


### PR DESCRIPTION
## Summary
- add FilePromptTemplateService tests verifying file reading and caching
- refactor PromptBuilder tests to use mocked template service and check chainability
- rewrite PromptDirector tests to assert builder method sequence with Vitest mocks

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68ae35a5e8fc8327903043b696803f6f