### PR TITLE
docs: document prompt architecture and update guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,16 @@
   `SQLiteDbProvider` implementation; business logic must use repository interfaces
   and remain database‑agnostic.
 
+## Prompts
+
+- Храните шаблоны промптов в каталоге `prompts/` и загружайте их через
+  `PromptTemplateService` вместо прямого чтения файлов.
+- Собирайте сообщения с помощью `PromptBuilder`, создавая новый билдер для
+  каждого промпта.
+- Логику выбора сценария выносите в `PromptDirector`.
+- Для новых сервисов или билдеров объявляйте интерфейсы и экспортируйте
+  символы Inversify.
+
 ## Code style
 
 - Remove unused parameters when possible; otherwise prefix them with an underscore


### PR DESCRIPTION
## Summary
- explain TemplateService → PromptBuilder → PromptDirector pipeline with example
- note migration steps from FilePromptService
- add prompt coding guidelines to AGENTS

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68ae37b1a6c48327897e47f004439d11