### PR TITLE
feat: add topic time setting for chats

### DIFF
--- a/migrations/013_add_topic_time_to_chat_configs.down.sql
+++ b/migrations/013_add_topic_time_to_chat_configs.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE chat_configs DROP COLUMN topic_time;

--- a/migrations/013_add_topic_time_to_chat_configs.up.sql
+++ b/migrations/013_add_topic_time_to_chat_configs.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE chat_configs ADD COLUMN topic_time TEXT NOT NULL DEFAULT '09:00';

--- a/src/application/interfaces/chat/ChatConfigService.errors.ts
+++ b/src/application/interfaces/chat/ChatConfigService.errors.ts
@@ -1,2 +1,3 @@
 export class InvalidHistoryLimitError extends Error {}
 export class InvalidInterestIntervalError extends Error {}
+export class InvalidTopicTimeError extends Error {}

--- a/src/application/interfaces/chat/ChatConfigService.ts
+++ b/src/application/interfaces/chat/ChatConfigService.ts
@@ -6,6 +6,7 @@ export interface ChatConfigService {
   getConfig(chatId: number): Promise<ChatConfigEntity>;
   setHistoryLimit(chatId: number, historyLimit: number): Promise<void>;
   setInterestInterval(chatId: number, interestInterval: number): Promise<void>;
+  setTopicTime(chatId: number, topicTime: string): Promise<void>;
   getTopicOfDaySchedules?(): Promise<Map<number, string>>;
 }
 

--- a/src/application/use-cases/chat/RepositoryChatConfigService.ts
+++ b/src/application/use-cases/chat/RepositoryChatConfigService.ts
@@ -4,6 +4,7 @@ import { type ChatConfigService } from '@/application/interfaces/chat/ChatConfig
 import {
   InvalidHistoryLimitError,
   InvalidInterestIntervalError,
+  InvalidTopicTimeError,
 } from '@/application/interfaces/chat/ChatConfigService.errors';
 import type { ChatConfigEntity } from '@/domain/entities/ChatConfigEntity';
 import {
@@ -13,6 +14,8 @@ import {
 
 const DEFAULT_HISTORY_LIMIT = 50;
 const DEFAULT_INTEREST_INTERVAL = 25;
+const DEFAULT_TOPIC_TIME = '09:00';
+const TOPIC_TIME_REGEX = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
 
 @injectable()
 export class RepositoryChatConfigService implements ChatConfigService {
@@ -27,6 +30,7 @@ export class RepositoryChatConfigService implements ChatConfigService {
         chatId,
         historyLimit: DEFAULT_HISTORY_LIMIT,
         interestInterval: DEFAULT_INTEREST_INTERVAL,
+        topicTime: DEFAULT_TOPIC_TIME,
       };
       await this.repo.upsert(config);
     }
@@ -62,5 +66,13 @@ export class RepositoryChatConfigService implements ChatConfigService {
 
   async getTopicOfDaySchedules(): Promise<Map<number, string>> {
     return new Map();
+  }
+
+  async setTopicTime(chatId: number, topicTime: string): Promise<void> {
+    if (!TOPIC_TIME_REGEX.test(topicTime)) {
+      throw new InvalidTopicTimeError('Invalid topic time');
+    }
+    const config = await this.getConfig(chatId);
+    await this.repo.upsert({ ...config, topicTime });
   }
 }

--- a/src/domain/entities/ChatConfigEntity.ts
+++ b/src/domain/entities/ChatConfigEntity.ts
@@ -2,4 +2,5 @@ export interface ChatConfigEntity {
   chatId: number;
   historyLimit: number;
   interestInterval: number;
+  topicTime: string;
 }

--- a/src/infrastructure/persistence/sqlite/SQLiteChatConfigRepository.ts
+++ b/src/infrastructure/persistence/sqlite/SQLiteChatConfigRepository.ts
@@ -17,13 +17,15 @@ export class SQLiteChatConfigRepository implements ChatConfigRepository {
     chatId,
     historyLimit,
     interestInterval,
+    topicTime,
   }: ChatConfigEntity): Promise<void> {
     const db = await this.dbProvider.get();
     await db.run(
-      'INSERT INTO chat_configs (chat_id, history_limit, interest_interval) VALUES (?, ?, ?) ON CONFLICT(chat_id) DO UPDATE SET history_limit=excluded.history_limit, interest_interval=excluded.interest_interval',
+      'INSERT INTO chat_configs (chat_id, history_limit, interest_interval, topic_time) VALUES (?, ?, ?, ?) ON CONFLICT(chat_id) DO UPDATE SET history_limit=excluded.history_limit, interest_interval=excluded.interest_interval, topic_time=excluded.topic_time',
       chatId,
       historyLimit,
-      interestInterval
+      interestInterval,
+      topicTime
     );
   }
 
@@ -33,8 +35,9 @@ export class SQLiteChatConfigRepository implements ChatConfigRepository {
       chat_id: number;
       history_limit: number;
       interest_interval: number;
+      topic_time: string;
     }>(
-      'SELECT chat_id, history_limit, interest_interval FROM chat_configs WHERE chat_id = ?',
+      'SELECT chat_id, history_limit, interest_interval, topic_time FROM chat_configs WHERE chat_id = ?',
       chatId
     );
     return row
@@ -42,6 +45,7 @@ export class SQLiteChatConfigRepository implements ChatConfigRepository {
           chatId: row.chat_id,
           historyLimit: row.history_limit,
           interestInterval: row.interest_interval,
+          topicTime: row.topic_time,
         }
       : undefined;
   }

--- a/test/ChatConfigServiceImpl.test.ts
+++ b/test/ChatConfigServiceImpl.test.ts
@@ -16,6 +16,7 @@ describe('RepositoryChatConfigService', () => {
       chatId: 1,
       historyLimit: 50,
       interestInterval: 25,
+      topicTime: '09:00',
     });
     expect(repo.upsert).toHaveBeenCalledWith(config);
   });
@@ -25,6 +26,7 @@ describe('RepositoryChatConfigService', () => {
       chatId: 1,
       historyLimit: 50,
       interestInterval: 25,
+      topicTime: '09:00',
     };
     const repo: ChatConfigRepository = {
       findById: vi.fn(async () => existing),
@@ -40,6 +42,7 @@ describe('RepositoryChatConfigService', () => {
       chatId: 1,
       historyLimit: 50,
       interestInterval: 25,
+      topicTime: '09:00',
     };
     const repo: ChatConfigRepository = {
       findById: vi.fn(async () => existing),
@@ -50,6 +53,25 @@ describe('RepositoryChatConfigService', () => {
     expect(repo.upsert).toHaveBeenCalledWith({
       ...existing,
       interestInterval: 20,
+    });
+  });
+
+  it('sets topic time', async () => {
+    const existing: ChatConfigEntity = {
+      chatId: 1,
+      historyLimit: 50,
+      interestInterval: 25,
+      topicTime: '09:00',
+    };
+    const repo: ChatConfigRepository = {
+      findById: vi.fn(async () => existing),
+      upsert: vi.fn(async () => {}),
+    };
+    const service = new RepositoryChatConfigService(repo);
+    await service.setTopicTime(1, '10:30');
+    expect(repo.upsert).toHaveBeenCalledWith({
+      ...existing,
+      topicTime: '10:30',
     });
   });
 });

--- a/test/ChatMemory.test.ts
+++ b/test/ChatMemory.test.ts
@@ -190,10 +190,12 @@ describe('ChatMemoryManager', () => {
         chatId,
         historyLimit: this.historyLimit,
         interestInterval: 0,
+        topicTime: '09:00',
       })
     );
     setHistoryLimit = vi.fn(async () => {});
     setInterestInterval = vi.fn(async () => {});
+    setTopicTime = vi.fn(async () => {});
   }
 
   it('creates ChatMemory with limit from ChatConfigService', async () => {

--- a/test/TelegramBot.test.ts
+++ b/test/TelegramBot.test.ts
@@ -91,6 +91,7 @@ class DummyChatConfigService {
   getConfig = vi.fn();
   setHistoryLimit = vi.fn(async () => {});
   setInterestInterval = vi.fn(async () => {});
+  setTopicTime = vi.fn(async () => {});
 }
 
 describe('TelegramBot', () => {
@@ -124,6 +125,7 @@ describe('TelegramBot', () => {
       chatId: 2,
       historyLimit: 50,
       interestInterval: 25,
+      topicTime: '09:00',
     });
     const bot = new TelegramBot(
       new MockEnvService() as unknown as EnvService,
@@ -645,6 +647,7 @@ describe('TelegramBot', () => {
       chatId: 42,
       historyLimit: 50,
       interestInterval: 25,
+      topicTime: '09:00',
     });
     const bot = new TelegramBot(
       new MockEnvService() as unknown as EnvService,
@@ -722,6 +725,7 @@ describe('TelegramBot', () => {
       chatId: 7,
       historyLimit: 50,
       interestInterval: 25,
+      topicTime: '09:00',
     });
     const bot = new TelegramBot(
       new MockEnvService() as unknown as EnvService,
@@ -787,6 +791,7 @@ describe('TelegramBot', () => {
       chatId: 7,
       historyLimit: 50,
       interestInterval: 25,
+      topicTime: '09:00',
     });
     const bot = new TelegramBot(
       new MockEnvService() as unknown as EnvService,


### PR DESCRIPTION
## Summary
- add migrations introducing `topic_time` for chat configs
- allow configuring daily topic time via ChatConfigService with HH:MM validation
- persist and test new topic time field

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68aed4a08c3c8327acda30a45a764d1f