### PR TITLE
feat: support timezone in TopicOfDayScheduler

### DIFF
--- a/src/application/interfaces/chat/ChatConfigService.ts
+++ b/src/application/interfaces/chat/ChatConfigService.ts
@@ -7,7 +7,9 @@ export interface ChatConfigService {
   setHistoryLimit(chatId: number, historyLimit: number): Promise<void>;
   setInterestInterval(chatId: number, interestInterval: number): Promise<void>;
   setTopicTime(chatId: number, topicTime: string | null): Promise<void>;
-  getTopicOfDaySchedules?(): Promise<Map<number, string>>;
+  getTopicOfDaySchedules?(): Promise<
+    Map<number, { time: string; timezone: string }>
+  >;
 }
 
 export const CHAT_CONFIG_SERVICE_ID = Symbol.for(

--- a/src/application/use-cases/chat/RepositoryChatConfigService.ts
+++ b/src/application/use-cases/chat/RepositoryChatConfigService.ts
@@ -64,7 +64,9 @@ export class RepositoryChatConfigService implements ChatConfigService {
     await this.repo.upsert({ ...config, interestInterval });
   }
 
-  async getTopicOfDaySchedules(): Promise<Map<number, string>> {
+  async getTopicOfDaySchedules(): Promise<
+    Map<number, { time: string; timezone: string }>
+  > {
     return new Map();
   }
 

--- a/src/application/use-cases/scheduler/TopicOfDayScheduler.ts
+++ b/src/application/use-cases/scheduler/TopicOfDayScheduler.ts
@@ -1,5 +1,5 @@
 import { inject, injectable } from 'inversify';
-import * as cron from 'node-cron';
+import cron from 'node-cron';
 
 import {
   AI_SERVICE_ID,
@@ -39,11 +39,16 @@ export class TopicOfDaySchedulerImpl implements TopicOfDayScheduler {
       this.logger.debug('No topic of day schedules');
       return;
     }
-    for (const [chatId, expr] of schedules) {
-      cron.schedule(expr, () => {
-        void this.execute(chatId);
-      });
-      this.logger.debug({ chatId, cron: expr }, 'Registered topic of day job');
+    for (const [chatId, { time, timezone }] of schedules) {
+      const [hourStr, minuteStr] = time.split(':');
+      const hour = Number(hourStr);
+      const minute = Number(minuteStr);
+      const expr = `0 ${minute} ${hour} * * *`;
+      cron.schedule(expr, () => void this.execute(chatId), { timezone });
+      this.logger.debug(
+        { chatId, cron: expr, timezone },
+        'Registered topic of day job'
+      );
     }
   }
 

--- a/test/TopicOfDayScheduler.test.ts
+++ b/test/TopicOfDayScheduler.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it, vi } from 'vitest';
-import * as cron from 'node-cron';
+import cron from 'node-cron';
 
-vi.mock('node-cron', () => ({ schedule: vi.fn() }));
+vi.mock('node-cron', () => ({ default: { schedule: vi.fn() } }));
 
 import { TopicOfDaySchedulerImpl } from '../src/application/use-cases/scheduler/TopicOfDayScheduler';
 
 describe('TopicOfDayScheduler', () => {
   it('schedules cron jobs and sends article', async () => {
     const chatConfig = {
-      getTopicOfDaySchedules: vi.fn(async () => new Map([[1, '* * * * *']])),
+      getTopicOfDaySchedules: vi.fn(
+        async () => new Map([[1, { time: '09:00', timezone: 'UTC' }]])
+      ),
     };
     const ai = { generateTopicOfDay: vi.fn(async () => 'article') };
     const bot = { sendMessage: vi.fn(async () => {}) };
@@ -30,15 +32,17 @@ describe('TopicOfDayScheduler', () => {
     );
 
     const scheduleMock = vi.mocked(cron.schedule);
-    scheduleMock.mockImplementation((_expr, _cb) => {
+    scheduleMock.mockImplementation((_expr, _cb, _opts) => {
       return {} as any;
     });
 
     await scheduler.start();
     expect(scheduleMock).toHaveBeenCalledWith(
-      '* * * * *',
-      expect.any(Function)
+      '0 0 9 * * *',
+      expect.any(Function),
+      { timezone: 'UTC' }
     );
+    scheduleMock.mock.calls[0][1]();
     await (scheduler as any).execute(1);
     expect(ai.generateTopicOfDay).toHaveBeenCalled();
     expect(bot.sendMessage).toHaveBeenCalledWith(1, 'article');


### PR DESCRIPTION
## Summary
- use default node-cron import
- pass configured timezone when scheduling TopicOfDay jobs
- derive cron expression from stored HH:mm time
- adjust ChatConfigService and tests for time/zone schedule

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68af05717b6c83278d7cb22be58b20de