### PR TITLE
feat: reschedule topic-of-day tasks

### DIFF
--- a/src/application/interfaces/scheduler/TopicOfDayScheduler.ts
+++ b/src/application/interfaces/scheduler/TopicOfDayScheduler.ts
@@ -2,6 +2,7 @@ import type { ServiceIdentifier } from 'inversify';
 
 export interface TopicOfDayScheduler {
   start(): Promise<void>;
+  reschedule(chatId: number): Promise<void>;
 }
 
 export const TOPIC_OF_DAY_SCHEDULER_ID = Symbol.for(

--- a/src/application/use-cases/chat/RepositoryChatConfigService.ts
+++ b/src/application/use-cases/chat/RepositoryChatConfigService.ts
@@ -1,4 +1,4 @@
-import { inject, injectable } from 'inversify';
+import { inject, injectable, LazyServiceIdentifier } from 'inversify';
 
 import { type ChatConfigService } from '@/application/interfaces/chat/ChatConfigService';
 import {
@@ -6,6 +6,10 @@ import {
   InvalidInterestIntervalError,
   InvalidTopicTimeError,
 } from '@/application/interfaces/chat/ChatConfigService.errors';
+import {
+  TOPIC_OF_DAY_SCHEDULER_ID,
+  type TopicOfDayScheduler,
+} from '@/application/interfaces/scheduler/TopicOfDayScheduler';
 import type { ChatConfigEntity } from '@/domain/entities/ChatConfigEntity';
 import {
   CHAT_CONFIG_REPOSITORY_ID,
@@ -21,7 +25,9 @@ const TOPIC_TIME_REGEX = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
 @injectable()
 export class RepositoryChatConfigService implements ChatConfigService {
   constructor(
-    @inject(CHAT_CONFIG_REPOSITORY_ID) private repo: ChatConfigRepository
+    @inject(CHAT_CONFIG_REPOSITORY_ID) private repo: ChatConfigRepository,
+    @inject(new LazyServiceIdentifier(() => TOPIC_OF_DAY_SCHEDULER_ID))
+    private readonly scheduler: TopicOfDayScheduler
   ) {}
 
   async getConfig(chatId: number): Promise<ChatConfigEntity> {
@@ -90,5 +96,6 @@ export class RepositoryChatConfigService implements ChatConfigService {
     }
     const config = await this.getConfig(chatId);
     await this.repo.upsert({ ...config, topicTime, topicTimezone });
+    await this.scheduler.reschedule(chatId);
   }
 }

--- a/test/ChatConfigServiceImpl.test.ts
+++ b/test/ChatConfigServiceImpl.test.ts
@@ -11,7 +11,8 @@ describe('RepositoryChatConfigService', () => {
       upsert: vi.fn(async () => {}),
       findAll: vi.fn(async () => []),
     };
-    const service = new RepositoryChatConfigService(repo);
+    const scheduler = { reschedule: vi.fn(async () => {}) };
+    const service = new RepositoryChatConfigService(repo, scheduler as any);
     const config = await service.getConfig(1);
     expect(config).toEqual({
       chatId: 1,
@@ -36,7 +37,8 @@ describe('RepositoryChatConfigService', () => {
       upsert: vi.fn(async () => {}),
       findAll: vi.fn(async () => []),
     };
-    const service = new RepositoryChatConfigService(repo);
+    const scheduler = { reschedule: vi.fn(async () => {}) };
+    const service = new RepositoryChatConfigService(repo, scheduler as any);
     await service.setHistoryLimit(1, 10);
     expect(repo.upsert).toHaveBeenCalledWith({ ...existing, historyLimit: 10 });
   });
@@ -54,7 +56,8 @@ describe('RepositoryChatConfigService', () => {
       upsert: vi.fn(async () => {}),
       findAll: vi.fn(async () => []),
     };
-    const service = new RepositoryChatConfigService(repo);
+    const scheduler = { reschedule: vi.fn(async () => {}) };
+    const service = new RepositoryChatConfigService(repo, scheduler as any);
     await service.setInterestInterval(1, 20);
     expect(repo.upsert).toHaveBeenCalledWith({
       ...existing,
@@ -75,13 +78,15 @@ describe('RepositoryChatConfigService', () => {
       upsert: vi.fn(async () => {}),
       findAll: vi.fn(async () => []),
     };
-    const service = new RepositoryChatConfigService(repo);
+    const scheduler = { reschedule: vi.fn(async () => {}) };
+    const service = new RepositoryChatConfigService(repo, scheduler as any);
     await service.setTopicTime(1, '10:30', 'Europe/Moscow');
     expect(repo.upsert).toHaveBeenCalledWith({
       ...existing,
       topicTime: '10:30',
       topicTimezone: 'Europe/Moscow',
     });
+    expect(scheduler.reschedule).toHaveBeenCalledWith(1);
   });
 
   it('clears topic time when null', async () => {
@@ -97,13 +102,15 @@ describe('RepositoryChatConfigService', () => {
       upsert: vi.fn(async () => {}),
       findAll: vi.fn(async () => []),
     };
-    const service = new RepositoryChatConfigService(repo);
+    const scheduler = { reschedule: vi.fn(async () => {}) };
+    const service = new RepositoryChatConfigService(repo, scheduler as any);
     await service.setTopicTime(1, null, 'UTC');
     expect(repo.upsert).toHaveBeenCalledWith({
       ...existing,
       topicTime: null,
       topicTimezone: 'UTC',
     });
+    expect(scheduler.reschedule).toHaveBeenCalledWith(1);
   });
 
   it('returns topic of day schedules', async () => {
@@ -127,7 +134,8 @@ describe('RepositoryChatConfigService', () => {
         },
       ]),
     } as unknown as ChatConfigRepository;
-    const service = new RepositoryChatConfigService(repo);
+    const scheduler = { reschedule: vi.fn(async () => {}) };
+    const service = new RepositoryChatConfigService(repo, scheduler as any);
     const schedules = await service.getTopicOfDaySchedules();
     expect(schedules).toEqual(
       new Map([[1, { cron: '0 30 10 * * *', timezone: 'UTC' }]])


### PR DESCRIPTION
## Summary
- track scheduled topic-of-day tasks and add rescheduling
- reschedule tasks when topic time changes
- cover topic time change flow with tests

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68af117867c48327ac1f4e96a60c7f9e