### PR TITLE
Add timezone selection for topic scheduling

### DIFF
--- a/src/view/telegram/windowConfig.ts
+++ b/src/view/telegram/windowConfig.ts
@@ -8,12 +8,14 @@ export type WindowId =
   | 'chat_history_limit'
   | 'chat_interest_interval'
   | 'chat_topic_time'
+  | 'chat_topic_timezone'
   | 'admin_menu'
   | 'admin_chats'
   | 'admin_chat'
   | 'admin_chat_history_limit'
   | 'admin_chat_interest_interval'
   | 'admin_chat_topic_time'
+  | 'admin_chat_topic_timezone'
   | 'chat_not_approved'
   | 'no_access'
   | 'chat_approval_request'
@@ -96,6 +98,13 @@ export function createWindows(actions: WindowActions): RouteApi<WindowId>[] {
       text: 'Введите время статьи (HH:MM):',
       buttons: [],
     })),
+    r('chat_topic_timezone', async ({ loadData }) => {
+      const { timezone } = (await loadData()) as { timezone: string };
+      return {
+        text: `Часовой пояс (${timezone}). Введите другой, если нужно:`,
+        buttons: [],
+      };
+    }),
     r('admin_menu', async () => ({
       text: 'Выберите действие:',
       buttons: [
@@ -181,6 +190,16 @@ export function createWindows(actions: WindowActions): RouteApi<WindowId>[] {
       const { chatId } = (await loadData()) as { chatId: number };
       return {
         text: `Введите время статьи для чата ${chatId} (HH:MM):`,
+        buttons: [],
+      };
+    }),
+    r('admin_chat_topic_timezone', async ({ loadData }) => {
+      const { chatId, timezone } = (await loadData()) as {
+        chatId: number;
+        timezone: string;
+      };
+      return {
+        text: `Часовой пояс для чата ${chatId} (${timezone}). Введите другой, если нужно:`,
         buttons: [],
       };
     }),

--- a/test/TelegramBot.test.ts
+++ b/test/TelegramBot.test.ts
@@ -231,9 +231,23 @@ describe('TelegramBot', () => {
         handleConfigTopicTime: (ctx: Context) => Promise<void>;
       }
     ).handleConfigTopicTime({ chat: { id: 14 } } as Context);
-    const ctxText = {
+    const ctxTime = {
       chat: { id: 14 },
       message: { text: 'bad' },
+      reply: vi.fn(),
+    } as unknown as Context;
+    await (
+      bot as unknown as { handleText: (ctx: Context) => Promise<void> }
+    ).handleText(ctxTime);
+    expect(showSpy).toHaveBeenNthCalledWith(
+      2,
+      ctxTime,
+      'chat_topic_timezone',
+      expect.anything()
+    );
+    const ctxZone = {
+      chat: { id: 14 },
+      message: { text: 'UTC' },
       reply: vi.fn(),
     } as unknown as Context;
     config.setTopicTime.mockImplementationOnce(async () => {
@@ -241,12 +255,12 @@ describe('TelegramBot', () => {
     });
     await (
       bot as unknown as { handleText: (ctx: Context) => Promise<void> }
-    ).handleText(ctxText);
+    ).handleText(ctxZone);
     expect(config.setTopicTime).toHaveBeenCalledWith(14, 'bad', 'UTC');
-    expect(ctxText.reply).toHaveBeenCalledWith(
+    expect(ctxZone.reply).toHaveBeenCalledWith(
       '❌ Время статьи должно быть в формате HH:MM'
     );
-    expect(showSpy).toHaveBeenCalledWith(ctxText, 'menu');
+    expect(showSpy).toHaveBeenNthCalledWith(3, ctxZone, 'menu');
   });
 
   it('updates interest interval on valid input', async () => {
@@ -312,17 +326,31 @@ describe('TelegramBot', () => {
         handleConfigTopicTime: (ctx: Context) => Promise<void>;
       }
     ).handleConfigTopicTime({ chat: { id: 30 } } as Context);
-    const ctxText = {
+    const ctxTime = {
       chat: { id: 30 },
       message: { text: '10:30' },
       reply: vi.fn(),
     } as unknown as Context;
     await (
       bot as unknown as { handleText: (ctx: Context) => Promise<void> }
-    ).handleText(ctxText);
+    ).handleText(ctxTime);
+    expect(showSpy).toHaveBeenNthCalledWith(
+      2,
+      ctxTime,
+      'chat_topic_timezone',
+      expect.anything()
+    );
+    const ctxZone = {
+      chat: { id: 30 },
+      message: { text: 'UTC' },
+      reply: vi.fn(),
+    } as unknown as Context;
+    await (
+      bot as unknown as { handleText: (ctx: Context) => Promise<void> }
+    ).handleText(ctxZone);
     expect(config.setTopicTime).toHaveBeenCalledWith(30, '10:30', 'UTC');
-    expect(ctxText.reply).toHaveBeenCalledWith('✅ Время статьи обновлено');
-    expect(showSpy).toHaveBeenCalledWith(ctxText, 'menu');
+    expect(ctxZone.reply).toHaveBeenCalledWith('✅ Время статьи обновлено');
+    expect(showSpy).toHaveBeenNthCalledWith(3, ctxZone, 'menu');
     expect(scheduler.reschedule).toHaveBeenCalledWith(30);
   });
 
@@ -527,6 +555,9 @@ describe('TelegramBot', () => {
       createLoggerFactory(),
       scheduler as unknown as TopicOfDayScheduler
     );
+    const routeSpy = vi
+      .spyOn((bot as unknown as { router: { show: Function } }).router, 'show')
+      .mockResolvedValue(undefined);
     const showSpy = vi
       .spyOn(
         bot as unknown as {
@@ -546,17 +577,31 @@ describe('TelegramBot', () => {
       { chat: { id: 1 }, reply: vi.fn() } as Context,
       50
     );
-    const ctxText = {
+    const ctxTime = {
       chat: { id: 1 },
       message: { text: '08:00' },
       reply: vi.fn(),
     } as unknown as Context;
     await (
       bot as unknown as { handleText: (ctx: Context) => Promise<void> }
-    ).handleText(ctxText);
+    ).handleText(ctxTime);
+    expect(routeSpy).toHaveBeenNthCalledWith(
+      2,
+      ctxTime,
+      'admin_chat_topic_timezone',
+      expect.anything()
+    );
+    const ctxZone = {
+      chat: { id: 1 },
+      message: { text: 'UTC' },
+      reply: vi.fn(),
+    } as unknown as Context;
+    await (
+      bot as unknown as { handleText: (ctx: Context) => Promise<void> }
+    ).handleText(ctxZone);
     expect(config.setTopicTime).toHaveBeenCalledWith(50, '08:00', 'UTC');
-    expect(ctxText.reply).toHaveBeenCalledWith('✅ Время статьи обновлено');
-    expect(showSpy).toHaveBeenCalledWith(ctxText, 50);
+    expect(ctxZone.reply).toHaveBeenCalledWith('✅ Время статьи обновлено');
+    expect(showSpy).toHaveBeenCalledWith(ctxZone, 50);
     expect(scheduler.reschedule).toHaveBeenCalledWith(50);
   });
 
@@ -687,6 +732,9 @@ describe('TelegramBot', () => {
       createLoggerFactory(),
       scheduler as unknown as TopicOfDayScheduler
     );
+    const routeSpy = vi
+      .spyOn((bot as unknown as { router: { show: Function } }).router, 'show')
+      .mockResolvedValue(undefined);
     const showSpy = vi
       .spyOn(
         bot as unknown as {
@@ -706,9 +754,23 @@ describe('TelegramBot', () => {
       { chat: { id: 1 }, reply: vi.fn() } as Context,
       46
     );
-    const ctxText = {
+    const ctxTime = {
       chat: { id: 1 },
       message: { text: 'bad' },
+      reply: vi.fn(),
+    } as unknown as Context;
+    await (
+      bot as unknown as { handleText: (ctx: Context) => Promise<void> }
+    ).handleText(ctxTime);
+    expect(routeSpy).toHaveBeenNthCalledWith(
+      2,
+      ctxTime,
+      'admin_chat_topic_timezone',
+      expect.anything()
+    );
+    const ctxZone = {
+      chat: { id: 1 },
+      message: { text: 'UTC' },
       reply: vi.fn(),
     } as unknown as Context;
     config.setTopicTime.mockImplementationOnce(async () => {
@@ -716,12 +778,12 @@ describe('TelegramBot', () => {
     });
     await (
       bot as unknown as { handleText: (ctx: Context) => Promise<void> }
-    ).handleText(ctxText);
+    ).handleText(ctxZone);
     expect(config.setTopicTime).toHaveBeenCalledWith(46, 'bad', 'UTC');
-    expect(ctxText.reply).toHaveBeenCalledWith(
+    expect(ctxZone.reply).toHaveBeenCalledWith(
       '❌ Время статьи должно быть в формате HH:MM'
     );
-    expect(showSpy).toHaveBeenCalledWith(ctxText, 46);
+    expect(showSpy).toHaveBeenCalledWith(ctxZone, 46);
     expect(scheduler.reschedule).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- ask for timezone after topic time entry and store it
- confirm timezone via new windows for users and admins
- adjust bot tests for two-step topic time configuration

## Testing
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68af21c8dc488327aa3550d87d832522