### PR TITLE
Fix circular dependency in TelegramBot scheduler injection

### DIFF
--- a/src/view/telegram/TelegramBot.ts
+++ b/src/view/telegram/TelegramBot.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 
-import { inject, injectable, optional } from 'inversify';
+import { inject, injectable, LazyServiceIdentifier, optional } from 'inversify';
 import type { Context } from 'telegraf';
 import { Telegraf } from 'telegraf';
 import { message } from 'telegraf/filters';
@@ -96,7 +96,7 @@ export class TelegramBot implements BotService {
     @inject(CHAT_INFO_SERVICE_ID) private chatInfo: ChatInfoService,
     @inject(CHAT_CONFIG_SERVICE_ID) private chatConfig: ChatConfigService,
     @inject(LOGGER_FACTORY_ID) loggerFactory: LoggerFactory,
-    @inject(TOPIC_OF_DAY_SCHEDULER_ID)
+    @inject(new LazyServiceIdentifier(() => TOPIC_OF_DAY_SCHEDULER_ID))
     @optional()
     private scheduler?: TopicOfDayScheduler
   ) {


### PR DESCRIPTION
## Summary
- lazily inject TopicOfDayScheduler into TelegramBot to avoid DI cycle

## Testing
- `npm run format:fix`
- `npm run build`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68af24911d2083278c130573b66217a0